### PR TITLE
Add FBSnapshotTestCaseAgnosticOption options mask for agnostic file names

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -101,6 +101,17 @@
 @property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
 
 /**
+ When set, allows fine-grained control over how agnostic you want the file names to be.
+
+ Allows you to combine which agnostic options you want in your snapshot file names.
+
+ The default value is FBSnapshotTestCaseAgnosticOptionNone.
+
+ @attention If deviceAgnostic is YES, this bitmask is ignored. deviceAgnostic will be deprecated in a future version of FBSnapshotTestCase.
+ */
+@property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -52,6 +52,17 @@
   _snapshotController.deviceAgnostic = deviceAgnostic;
 }
 
+- (FBSnapshotTestCaseAgnosticOption)agnosticOptions
+{
+    return _snapshotController.agnosticOptions;
+}
+
+- (void)setAgnosticOptions:(FBSnapshotTestCaseAgnosticOption)agnosticOptions
+{
+    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+    _snapshotController.agnosticOptions = agnosticOptions;
+}
+
 - (BOOL)usesDrawViewHierarchyInRect
 {
   return _snapshotController.usesDrawViewHierarchyInRect;

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -15,6 +15,21 @@ extern "C" {
 #endif
 
 /**
+ An option mask that allows you to cherry pick which parts you want to 'be agnostic' in the snapshot file name.
+
+ - FBSnapshotTestCaseAgnosticOptionNone: Don't make the file name agnostic at all.
+ - FBSnapshotTestCaseAgnosticOptionDevice: The file name should be agnostic on the device name, as returned by UIDevice.currentDevice.model.
+ - FBSnapshotTestCaseAgnosticOptionOS: The file name should be agnostic on the OS version, as returned by UIDevice.currentDevice.systemVersion.
+ - FBSnapshotTestCaseAgnosticOptionScreenSize: The file name should be agnostic on the screen size of the current keyWindow, as returned by UIApplication.sharedApplication.keyWindow.bounds.size.
+ */
+typedef NS_OPTIONS(NSUInteger, FBSnapshotTestCaseAgnosticOption) {
+  FBSnapshotTestCaseAgnosticOptionNone = 1 << 0,
+  FBSnapshotTestCaseAgnosticOptionDevice = 1 << 1,
+  FBSnapshotTestCaseAgnosticOptionOS = 1 << 2,
+  FBSnapshotTestCaseAgnosticOptionScreenSize = 1 << 3
+};
+
+/**
  Returns a Boolean value that indicates whether the snapshot test is running in 64Bit.
  This method is a convenience for creating the suffixes set based on the architecture
  that the test is running.
@@ -38,6 +53,15 @@ NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void);
  @returns An @c NSString object containing the passed @c fileName with the device model, OS and screen size appended at the end.
  */
 NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName);
+
+/**
+ Returns a fully normalized file name as per the provided option mask. Strips punctuation and spaces and replaces them with @c _.
+
+ @param fileName The file name to normalize.
+ @param option Agnostic options to use before normalization.
+ @return An @c NSString object containing the passed @c fileName and optionally, with the device model and/or OS and/or screen size appended at the end.
+ */
+NSString *FBDeviceAgnosticNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseAgnosticOption option);
 
 #ifdef __cplusplus
 }

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -49,3 +49,31 @@ NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName)
   
   return fileName;
 }
+
+NSString *FBDeviceAgnosticNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseAgnosticOption option)
+{
+  if ((option & FBSnapshotTestCaseAgnosticOptionDevice) == FBSnapshotTestCaseAgnosticOptionDevice) {
+    UIDevice *device = [UIDevice currentDevice];
+    fileName = [fileName stringByAppendingFormat:@"_%@", device.model];
+  }
+
+  if ((option & FBSnapshotTestCaseAgnosticOptionOS) == FBSnapshotTestCaseAgnosticOptionOS) {
+    UIDevice *device = [UIDevice currentDevice];
+    NSString *os = device.systemVersion;
+    fileName = [fileName stringByAppendingFormat:@"_%@", os];
+  }
+
+  if ((option & FBSnapshotTestCaseAgnosticOptionScreenSize) == FBSnapshotTestCaseAgnosticOptionScreenSize) {
+    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+    CGSize screenSize = keyWindow.bounds.size;
+    fileName = [fileName stringByAppendingFormat:@"_%.0fx%.0f", screenSize.width, screenSize.height];
+  }
+
+  NSMutableCharacterSet *invalidCharacters = [NSMutableCharacterSet new];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
+  NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
+  fileName = [validComponents componentsJoinedByString:@"_"];
+
+  return fileName;
+}

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -11,6 +11,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+
 typedef NS_ENUM(NSInteger, FBSnapshotTestControllerErrorCode) {
   FBSnapshotTestControllerErrorCodeUnknown,
   FBSnapshotTestControllerErrorCodeNeedsRecord,
@@ -18,6 +20,7 @@ typedef NS_ENUM(NSInteger, FBSnapshotTestControllerErrorCode) {
   FBSnapshotTestControllerErrorCodeImagesDifferentSizes,
   FBSnapshotTestControllerErrorCodeImagesDifferent,
 };
+
 /**
  Errors returned by the methods of FBSnapshotTestController use this domain.
  */
@@ -60,6 +63,17 @@ extern NSString *const FBDiffedImageKey;
  The default value is @c NO.
  */
 @property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
+ When set, allows fine-grained control over how agnostic you want the file names to be.
+
+ Allows you to combine which agnostic options you want in your snapshot file names.
+
+ The default value is FBSnapshotTestCaseAgnosticOptionNone.
+
+ @attention If deviceAgnostic is YES, this bitmask is ignored. deviceAgnostic will be deprecated in a future version of FBSnapshotTestCase.
+ */
+@property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
 
 /**
  Uses drawViewHierarchyInRect:afterScreenUpdates: to draw the image instead of renderInContext:


### PR DESCRIPTION
This allows people to opt–in to which parts of the the existing deviceAgnostic flag they want to use.

Since we're not deleting `deviceAgnostic` for now (it would require a major version bump) this change is additive.