### PR TITLE
Allowing flexible folder names and trimming test words from image names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.1.0
+
+  - Adds the ability to set folder name where snapshots are going to be saved for each test case.
+
 ## 3.0.0
 
   - Project has been relicensed to MIT via the original project and Facebook's PATENTS file has been removed with their blessing. Thank you Facebook!

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -111,24 +111,6 @@
 @property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
 
 /**
- Sets the folder name in which the snapshopt is going to be saved.
-
- The default name is the name of the class where the tests are being ran.
-
- This property *must* be called *AFTER* [super setUp].
- */
-@property (readwrite, nonatomic, copy) NSString *folderName;
-
-/**
- If set to true, this will remove the `test` prefix from the image name.
-
- This property *must* be called *AFTER* [super setUp].
-
- Defaults to false.
- */
-@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
-
-/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70
@@ -141,6 +123,13 @@
 
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
+
+/**
+ This method is called when FBSnapshotTestCase subclass is initialized. You can override it to set the
+ folder where all images are going to be saved. It defaults to the class name. In swift, this means
+ `ModuleName.ClassName`.
+ */
+- (NSString * _Nonnull)getFolderName;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -111,6 +111,11 @@
 @property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
 
 /**
+ Sets the folder name in which the snapshot is going to be saved. This property *must* be called *AFTER* [super setUp].
+ */
+@property (readwrite, nonatomic, copy) NSString *folderName;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70
@@ -123,13 +128,6 @@
 
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
-
-/**
- This method is called when FBSnapshotTestCase subclass is initialized. You can override it to set the
- folder where all images are going to be saved. It defaults to the class name. In swift, this means
- `ModuleName.ClassName`.
- */
-- (NSString * _Nonnull)getFolderName;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -111,6 +111,24 @@
 @property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
 
 /**
+ Sets the folder name in which the snapshopt is going to be saved.
+
+ The default name is the name of the class where the tests are being ran.
+
+ This property *must* be called *AFTER* [super setUp].
+ */
+@property (readwrite, nonatomic, copy) NSString *folderName;
+
+/**
+ If set to true, this will remove the `test` prefix from the image name.
+
+ This property *must* be called *AFTER* [super setUp].
+
+ Defaults to false.
+ */
+@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -10,6 +10,10 @@
 #import <FBSnapshotTestCase/FBSnapshotTestCase.h>
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
+@interface FBSnapshotTestCase ()
+  @property (nonatomic, strong, nonnull) NSString *folderName;
+@end
+
 @implementation FBSnapshotTestCase
 {
   FBSnapshotTestController *_snapshotController;
@@ -17,10 +21,24 @@
 
 #pragma mark - Overrides
 
+- (instancetype)initWithInvocation:(NSInvocation *)invocation
+{
+  if (self = [super initWithInvocation:invocation]) {
+
+    self.folderName = [self getFolderName];
+  }
+  return self;
+}
+
+- (NSString * _Nonnull)getFolderName
+{
+  return NSStringFromClass([self class]);
+}
+
 - (void)setUp
 {
   [super setUp];
-  _snapshotController = [[FBSnapshotTestController alloc] initWithTestName:NSStringFromClass([self class])];
+  _snapshotController = [[FBSnapshotTestController alloc] initWithTestName:self.folderName];
 }
 
 - (void)tearDown
@@ -72,29 +90,6 @@
   NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
-
--(NSString *)folderName
-{
-  return _snapshotController.testName;
-}
-
-- (void)setFolderName:(NSString *)folderName
-{
-  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.testName = folderName;
-}
-
--(void)setTrimTestPrefixFromImageName:(BOOL)trimTestPrefixFromImageName
-{
-  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.trimTestPrefixFromImageName = trimTestPrefixFromImageName;
-}
-
--(BOOL)trimTestPrefixFromImageName
-{
-  return _snapshotController.trimTestPrefixFromImageName;
-}
-
 
 #pragma mark - Public API
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -10,10 +10,6 @@
 #import <FBSnapshotTestCase/FBSnapshotTestCase.h>
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
-@interface FBSnapshotTestCase ()
-  @property (nonatomic, strong, nonnull) NSString *folderName;
-@end
-
 @implementation FBSnapshotTestCase
 {
   FBSnapshotTestController *_snapshotController;
@@ -21,24 +17,10 @@
 
 #pragma mark - Overrides
 
-- (instancetype)initWithInvocation:(NSInvocation *)invocation
-{
-  if (self = [super initWithInvocation:invocation]) {
-
-    self.folderName = [self getFolderName];
-  }
-  return self;
-}
-
-- (NSString *)getFolderName
-{
-  return NSStringFromClass([self class]);
-}
-
 - (void)setUp
 {
   [super setUp];
-  _snapshotController = [[FBSnapshotTestController alloc] initWithTestName:self.folderName];
+  _snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[self class]];
 }
 
 - (void)tearDown
@@ -89,6 +71,16 @@
 {
   NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
+}
+
+-(NSString *)folderName
+{
+    return _snapshotController.folderName;
+}
+
+- (void)setFolderName:(NSString *)folderName
+{
+    _snapshotController.folderName = folderName;
 }
 
 #pragma mark - Public API

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -30,7 +30,7 @@
   return self;
 }
 
-- (NSString * _Nonnull)getFolderName
+- (NSString *)getFolderName
 {
   return NSStringFromClass([self class]);
 }

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -73,6 +73,29 @@
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
 
+-(NSString *)folderName
+{
+  return _snapshotController.testName;
+}
+
+- (void)setFolderName:(NSString *)folderName
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.testName = folderName;
+}
+
+-(void)setTrimTestPrefixFromImageName:(BOOL)trimTestPrefixFromImageName
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.trimTestPrefixFromImageName = trimTestPrefixFromImageName;
+}
+
+-(BOOL)trimTestPrefixFromImageName
+{
+  return _snapshotController.trimTestPrefixFromImageName;
+}
+
+
 #pragma mark - Public API
 
 - (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -85,11 +85,6 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
- The name of the test. This will be used to create folders with the specified name.
- */
-@property (readwrite, nonatomic, copy) NSString *testName;
-
-/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -90,13 +90,6 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *testName;
 
 /**
- If set to true, this will remove the `test` prefix from the image name.
-
- Defaults to false.
- */
-@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
-
-/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -85,6 +85,18 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
+ The name of the test. This will be used to create folders with the specified name.
+ */
+@property (readwrite, nonatomic, copy) NSString *testName;
+
+/**
+ If set to true, this will remove the `test` prefix from the image name.
+
+ Defaults to false.
+ */
+@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -85,17 +85,15 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
+ The name folder in which the snapshots will be saved for a given test case.
+*/
+@property (readwrite, nonatomic, copy) NSString *folderName;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */
 - (instancetype)initWithTestClass:(Class)testClass;
-
-/**
- Designated initializer.
- @param testName The name of the tests.
- @returns An instance of FBSnapshotTestController.
- */
-- (instancetype)initWithTestName:(NSString *)testName;
 
 /**
  Performs the comparison of the layer.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 @implementation FBSnapshotTestController
 {
+  NSString *_testName;
   NSFileManager *_fileManager;
 }
 
@@ -252,9 +253,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:FBTestSnapshotFileNameTypeReference];
-
-  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.testName];
-
+  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:_testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }
@@ -270,7 +269,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (getenv("IMAGE_DIFF_DIR")) {
     folderPath = @(getenv("IMAGE_DIFF_DIR"));
   }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:self.testName];
+  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -30,7 +30,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 @implementation FBSnapshotTestController
 {
-  NSString *_testName;
   NSFileManager *_fileManager;
 }
 
@@ -38,13 +37,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 - (instancetype)initWithTestClass:(Class)testClass;
 {
-  return [self initWithTestName:NSStringFromClass(testClass)];
-}
-
-- (instancetype)initWithTestName:(NSString *)testName
-{
   if (self = [super init]) {
-    _testName = [testName copy];
+    self.folderName = NSStringFromClass(testClass);
     _deviceAgnostic = NO;
     _agnosticOptions = FBSnapshotTestCaseAgnosticOptionNone;
 
@@ -253,7 +247,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:FBTestSnapshotFileNameTypeReference];
-  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:_testName];
+  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.folderName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }
@@ -269,7 +263,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (getenv("IMAGE_DIFF_DIR")) {
     folderPath = @(getenv("IMAGE_DIFF_DIR"));
   }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
+  NSString *filePath = [folderPath stringByAppendingPathComponent:self.folderName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -30,7 +30,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 @implementation FBSnapshotTestController
 {
-  NSString *_testName;
   NSFileManager *_fileManager;
 }
 
@@ -233,6 +232,15 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
 
+  if (self.trimTestPrefixFromImageName) {
+
+    NSString *testPrefix = @"test";
+
+    if ([fileName hasPrefix:testPrefix]) {
+      fileName = [fileName substringFromIndex:testPrefix.length];
+    }
+  }
+
   BOOL noAgnosticOption = (self.agnosticOptions & FBSnapshotTestCaseAgnosticOptionNone) == FBSnapshotTestCaseAgnosticOptionNone;
   if (self.isDeviceAgnostic) {
     fileName = FBDeviceAgnosticNormalizedFileName(fileName);
@@ -253,7 +261,9 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:FBTestSnapshotFileNameTypeReference];
-  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:_testName];
+
+  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.testName];
+
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }
@@ -269,7 +279,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (getenv("IMAGE_DIFF_DIR")) {
     folderPath = @(getenv("IMAGE_DIFF_DIR"));
   }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
+  NSString *filePath = [folderPath stringByAppendingPathComponent:self.testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -232,15 +232,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
 
-  if (self.trimTestPrefixFromImageName) {
-
-    NSString *testPrefix = @"test";
-
-    if ([fileName hasPrefix:testPrefix]) {
-      fileName = [fileName substringFromIndex:testPrefix.length];
-    }
-  }
-
   BOOL noAgnosticOption = (self.agnosticOptions & FBSnapshotTestCaseAgnosticOptionNone) == FBSnapshotTestCaseAgnosticOptionNone;
   if (self.isDeviceAgnostic) {
     fileName = FBDeviceAgnosticNormalizedFileName(fileName);

--- a/iOSSnapshotTestCase.podspec
+++ b/iOSSnapshotTestCase.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "iOSSnapshotTestCase"
   s.module_name  = "FBSnapshotTestCase"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "Snapshot view unit tests for iOS"
   s.description  = <<-DESC
                     A "snapshot test case" takes a configured UIView or CALayer


### PR DESCRIPTION
Hi, 

As discussed in #8 I took the liberty to try an implementation that would keep the current behaviour while adding two different possibilities:

- Allow the `folderName` to be set, which will impact the folder in which the images will be saved.
- Allow trimming the `test` prefix of the images names. 

This also impacts the Failure folder.

# Before &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; After
<img width="224" alt="screenshot 2018-02-25 12 22 12" src="https://user-images.githubusercontent.com/3007012/36641367-86a87626-1a26-11e8-9258-269ae9a750f6.png">&nbsp; &nbsp; &nbsp; &nbsp; <img width="153" alt="screenshot 2018-02-25 12 13 55" src="https://user-images.githubusercontent.com/3007012/36641340-020dd8b6-1a26-11e8-9d41-6542b334560c.png">

In my opinion this makes up for better readability, and also helps referencing custom views. 

You can also create subfolders using `folderName = "folder/subfolder"` which allows you to have:

<img width="193" alt="screenshot 2018-02-25 12 31 45" src="https://user-images.githubusercontent.com/3007012/36641485-dc028f02-1a27-11e8-9e6f-3dcce8d9e1c1.png">

Note:
I have almost no experience with objective-C, so if there's anything that might not be in the best way, accept my apologies and please let me know.