### PR TITLE
Allow flexible folder names and trimming test words from image names

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -112,6 +112,24 @@
 @property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
 
 /**
+ Sets the folder name in which the snapshopt is going to be saved.
+
+ The default name is the name of the class where the tests are being ran.
+
+ This property *must* be called *AFTER* [super setUp].
+*/
+@property (readwrite, nonatomic, copy) NSString *folderName;
+
+/**
+ If set to true, this will remove the `test` prefix from the image name.
+
+ This property *must* be called *AFTER* [super setUp].
+
+ Defaults to false.
+*/
+@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -74,6 +74,28 @@
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
 
+-(NSString *)folderName
+{
+  return _snapshotController.testName;
+}
+
+- (void)setFolderName:(NSString *)folderName
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.testName = folderName;
+}
+
+-(void)setTrimTestPrefixFromImageName:(BOOL)trimTestPrefixFromImageName
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.trimTestPrefixFromImageName = trimTestPrefixFromImageName;
+}
+
+-(BOOL)trimTestPrefixFromImageName
+{
+  return _snapshotController.trimTestPrefixFromImageName;
+}
+
 #pragma mark - Public API
 
 - (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -86,6 +86,17 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
+ The name of the test. This will be used to create folders with the specified name.
+ */
+@property (readwrite, nonatomic, copy) NSString *testName;
+
+/**
+ If set to true, this will remove the `test` prefix from the image name.
+ Defaults to false.
+ */
+@property (readwrite, nonatomic, assign) BOOL trimTestPrefixFromImageName;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -31,7 +31,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 @implementation FBSnapshotTestController
 {
-  NSString *_testName;
   NSFileManager *_fileManager;
 }
 
@@ -112,10 +111,10 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
       *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
                                       code:FBSnapshotTestControllerErrorCodeNeedsRecord
                                   userInfo:@{
-               FBReferenceImageFilePathKey: filePath,
-                 NSLocalizedDescriptionKey: @"Unable to load reference image.",
-          NSLocalizedFailureReasonErrorKey: @"Reference image not found. You need to run the test in record mode",
-                   }];
+                                             FBReferenceImageFilePathKey: filePath,
+                                             NSLocalizedDescriptionKey: @"Unable to load reference image.",
+                                             NSLocalizedFailureReasonErrorKey: @"Reference image not found. You need to run the test in record mode",
+                                             }];
     } else {
       *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
                                       code:FBSnapshotTestControllerErrorCodeUnknown
@@ -138,7 +137,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (NULL != errorPtr) {
     NSString *errorDescription = sameImageDimensions ? @"Images different" : @"Images different sizes";
     NSString *errorReason = sameImageDimensions ? [NSString stringWithFormat:@"image pixels differed by more than %.2f%% from the reference image", tolerance * 100]
-                                                : [NSString stringWithFormat:@"referenceImage:%@, image:%@", NSStringFromCGSize(referenceImage.size), NSStringFromCGSize(image.size)];
+    : [NSString stringWithFormat:@"referenceImage:%@, image:%@", NSStringFromCGSize(referenceImage.size), NSStringFromCGSize(image.size)];
     FBSnapshotTestControllerErrorCode errorCode = sameImageDimensions ? FBSnapshotTestControllerErrorCodeImagesDifferent : FBSnapshotTestControllerErrorCodeImagesDifferentSizes;
 
     *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
@@ -234,6 +233,15 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
 
+  if (self.trimTestPrefixFromImageName) {
+
+    NSString *testPrefix = @"test";
+
+    if ([fileName hasPrefix:testPrefix]) {
+      fileName = [fileName substringFromIndex:testPrefix.length];
+    }
+  }
+
   BOOL noAgnosticOption = (self.agnosticOptions & FBSnapshotTestCaseAgnosticOptionNone) == FBSnapshotTestCaseAgnosticOptionNone;
   if (self.isDeviceAgnostic) {
     fileName = FBDeviceAgnosticNormalizedFileName(fileName);
@@ -254,7 +262,9 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:FBTestSnapshotFileNameTypeReference];
-  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:_testName];
+
+  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.testName];
+
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }
@@ -270,7 +280,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (getenv("IMAGE_DIFF_DIR")) {
     folderPath = @(getenv("IMAGE_DIFF_DIR"));
   }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
+  NSString *filePath = [folderPath stringByAppendingPathComponent:self.testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }


### PR DESCRIPTION
These changes will be introduced soon in the main library, but we need them already.

Original pull request here: https://github.com/uber/ios-snapshot-test-case/pull/14