### PR TITLE
Implement AutoRecord for new snapshots.

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -137,6 +137,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ When YES, a test will run and fail when no reference image exists, without needing to run
+ recordMode first. The fail image is stored and can be reviewed and accepted as a reference.
+ */
+@property (readwrite, nonatomic, assign) BOOL autoRecord;
+
+/**
  When set, allows fine-grained control over what you want the file names to include.
 
  Allows you to combine which device or simulator specific details you want in your snapshot file names.
@@ -147,7 +153,6 @@ NS_ASSUME_NONNULL_BEGIN
 
  self.fileNameOptions = (FBSnapshotTestCaseFileNameIncludeOptionDevice | FBSnapshotTestCaseFileNameIncludeOptionOS);
  */
-
 @property (readwrite, nonatomic, assign) FBSnapshotTestCaseFileNameIncludeOption fileNameOptions;
 
 /**
@@ -206,6 +211,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 overallTolerance:(CGFloat)overallTolerance
                        defaultReferenceDirectory:(nullable NSString *)defaultReferenceDirectory
                        defaultImageDiffDirectory:(nullable NSString *)defaultImageDiffDirectory;
+
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -55,6 +55,11 @@ extern NSString *const FBDiffedImageKey;
 @interface FBSnapshotTestController : NSObject
 
 /**
+ Auto record snapshots on first run of new tests.
+ */
+@property (readwrite, nonatomic, assign) BOOL autoRecord;
+
+/**
  Record snapshots.
  */
 @property (readwrite, nonatomic, assign) BOOL recordMode;

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -8,56 +8,66 @@
  */
 
 public extension FBSnapshotTestCase {
-  public func FBSnapshotVerifyView(_ view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
-  }
-
-  public func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
-  }
-
-  private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-    let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: FB_REFERENCE_IMAGE_DIR)
-    let envImageDiffDirectory = self.getImageDiffDirectory(withDefault: IMAGE_DIFF_DIR)
-    var error: NSError?
-    var comparisonSuccess = false
-
-    for suffix in suffixes {
-      let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
-      let imageDiffDirectory = envImageDiffDirectory
-      if viewOrLayer.isKind(of: UIView.self) {
-        do {
-          try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
-          comparisonSuccess = true
-        } catch let error1 as NSError {
-          error = error1
-          comparisonSuccess = false
-        }
-      } else if viewOrLayer.isKind(of: CALayer.self) {
-        do {
-          try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
-          comparisonSuccess = true
-        } catch let error1 as NSError {
-          error = error1
-          comparisonSuccess = false
-        }
-      } else {
-        assertionFailure("Only UIView and CALayer classes can be snapshotted")
-      }
-
-      assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
-
-      if comparisonSuccess || recordMode {
-        break
-      }
-
-      assert(comparisonSuccess, message: "Snapshot comparison failed: \(String(describing: error))", file: file, line: line)
+    public func FBSnapshotVerifyView(_ view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+        FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
     }
-  }
-
-  func assert(_ assertion: Bool, message: String, file: StaticString, line: UInt) {
-    if !assertion {
-      XCTFail(message, file: file, line: line)
+    
+    public func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+        FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
     }
-  }
+    
+    private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+        let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: FB_REFERENCE_IMAGE_DIR)
+        let envImageDiffDirectory = self.getImageDiffDirectory(withDefault: IMAGE_DIFF_DIR)
+        var error: NSError?
+        var comparisonSuccess = false
+        
+        for suffix in suffixes {
+            let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
+            let imageDiffDirectory = envImageDiffDirectory
+
+            if viewOrLayer.isKind(of: UIView.self) {
+                do {
+                    try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
+                    comparisonSuccess = true
+                } catch let error1 as NSError {
+                    error = error1
+                    comparisonSuccess = false
+                }
+            } else if viewOrLayer.isKind(of: CALayer.self) {
+                do {
+                    try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
+                    comparisonSuccess = true
+                } catch let error1 as NSError {
+                    error = error1
+                    comparisonSuccess = false
+                }
+            } else {
+                assertionFailure("Only UIView and CALayer classes can be snapshotted")
+            }
+            
+            assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
+            
+            if comparisonSuccess || recordMode {
+                break
+            }
+
+            var referenceFilePath = referenceImagesDirectory.appending("\(identifier)")
+            var referenceImageExists: Bool = FileManager.default.fileExists(atPath: referenceFilePath)
+            
+            assert(self.autoRecord == false || referenceImageExists, message: "No previous reference image. New image has been stored for approval.", file: file, line: line)
+            
+            if self.autoRecord && !referenceImageExists {
+                break
+            }
+            
+            assert(comparisonSuccess, message: "Snapshot comparison failed: \(String(describing: error))", file: file, line: line)
+        }
+    }
+    
+    func assert(_ assertion: Bool, message: String, file: StaticString, line: UInt) {
+        if !assertion {
+            XCTFail(message, file: file, line: line)
+        }
+    }
 }


### PR DESCRIPTION
Provides an autoRecord parameter. If set, new tests that do not have a reference image will still execute, will return a failure, and will provide a fail image which is a snapshot of the view. This provides the opportunity for the user to review the image and decide whether to set it as a reference image. If recordMode == true, autoRecord is ignored and behavior is as previously.