### PR TITLE
New device agnostic option to avoid the suffix in the snapshots

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -20,12 +20,14 @@ extern "C" {
  - FBSnapshotTestCaseAgnosticOptionDevice: The file name should be agnostic on the device name, as returned by UIDevice.currentDevice.model.
  - FBSnapshotTestCaseAgnosticOptionOS: The file name should be agnostic on the OS version, as returned by UIDevice.currentDevice.systemVersion.
  - FBSnapshotTestCaseAgnosticOptionScreenSize: The file name should be agnostic on the screen size of the current keyWindow, as returned by UIApplication.sharedApplication.keyWindow.bounds.size.
+ - FBSnapshotTestCaseAgnosticOptionNoSuffix: The file name should not have a suffix concatenated to it regarding the dimension ("@2x" or "@3x", for instance).
  */
 typedef NS_OPTIONS(NSUInteger, FBSnapshotTestCaseAgnosticOption) {
   FBSnapshotTestCaseAgnosticOptionNone = 1 << 0,
   FBSnapshotTestCaseAgnosticOptionDevice = 1 << 1,
   FBSnapshotTestCaseAgnosticOptionOS = 1 << 2,
-  FBSnapshotTestCaseAgnosticOptionScreenSize = 1 << 3
+  FBSnapshotTestCaseAgnosticOptionScreenSize = 1 << 3,
+  FBSnapshotTestCaseAgnosticOptionNoSuffix = 1 << 4
 };
 
 /**

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -240,7 +240,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     fileName = FBDeviceAgnosticNormalizedFileNameFromOption(fileName, self.agnosticOptions);
   }
 
-  if ([[UIScreen mainScreen] scale] > 1) {
+  BOOL noSuffixOption = (self.agnosticOptions & FBSnapshotTestCaseAgnosticOptionNoSuffix) == FBSnapshotTestCaseAgnosticOptionNoSuffix;
+  if ([[UIScreen mainScreen] scale] > 1 && !noSuffixOption) {
     fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
   }
   fileName = [fileName stringByAppendingPathExtension:@"png"];

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -108,6 +108,33 @@
   XCTAssertTrue([(NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey] containsString:deviceAgnosticReferencePath]);
 }
 
+- (void)testImageWithoutSuffixIfAgnosticOptionIsUsed
+{
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  [controller setDeviceAgnostic:YES];
+  [controller setAgnosticOptions:FBSnapshotTestCaseAgnosticOptionNoSuffix];
+  [controller setReferenceImagesDirectory:@"/dev/null/"];
+  NSError *error = nil;
+  SEL selector = @selector(isDeviceAgnostic);
+  [controller referenceImageForSelector:selector identifier:@"" error:&error];
+  XCTAssertNotNil(error);
+  NSString *imageFilePath = (NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey];
+  XCTAssertTrue([[imageFilePath componentsSeparatedByString:@"@"] count] == 1);
+}
+
+- (void)testImageWithSuffixIfAgnosticOptionIsNotUsed
+{
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  [controller setDeviceAgnostic:YES];
+  [controller setReferenceImagesDirectory:@"/dev/null/"];
+  NSError *error = nil;
+  SEL selector = @selector(isDeviceAgnostic);
+  [controller referenceImageForSelector:selector identifier:@"" error:&error];
+  XCTAssertNotNil(error);
+  NSString *imageFilePath = (NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey];
+  XCTAssertTrue([[imageFilePath componentsSeparatedByString:@"@"] count] == 2);
+}
+
 #pragma mark - Private helper methods
 
 - (UIImage *)_bundledImageNamed:(NSString *)name type:(NSString *)type


### PR DESCRIPTION
Adding an option to the agnostic snapshots to avoid the addition of the suffixes regarding dimension.