### PR TITLE
Add failedImagesDirectory property on FBSnapshotTestController

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -85,6 +85,12 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
+ The directory in which failed images will be stored.
+ Default: value of environment variable IMAGE_DIFF_DIR if exist, temporary folder otherwise
+ */
+@property (readwrite, nonatomic, copy) NSString *failedImagesDirectory;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -48,6 +48,12 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     _deviceAgnostic = NO;
     _agnosticOptions = FBSnapshotTestCaseAgnosticOptionNone;
 
+    if (getenv("IMAGE_DIFF_DIR")) {
+      _failedImagesDirectory = @(getenv("IMAGE_DIFF_DIR"));
+    } else {
+      _failedImagesDirectory = NSTemporaryDirectory();
+    }
+
     _fileManager = [[NSFileManager alloc] init];
   }
   return self;
@@ -265,11 +271,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:fileNameType];
-  NSString *folderPath = NSTemporaryDirectory();
-  if (getenv("IMAGE_DIFF_DIR")) {
-    folderPath = @(getenv("IMAGE_DIFF_DIR"));
-  }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
+  NSString *filePath = [_failedImagesDirectory stringByAppendingPathComponent:_testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }


### PR DESCRIPTION
## Usecase:
We setup `IMAGE_DIFF_DIR` to be in our repo, so when any test fails on simulator we can find diff images in repo. But when you run tests on real device and it fails, device don't have write access to project folder.

## Our solution:
Add ability to specify `failedImageDirectory` in runtime, so for real devices we can set it to some temporary folder.