### PR TITLE
Add support for overriding the failed diff directory

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -31,6 +31,20 @@
 #define FB_REFERENCE_IMAGE_DIR ""
 #endif
 
+/*
+ There are three ways of setting failed image diff directories.
+
+ 1. Set the preprocessor macro IMAGE_DIFF_DIR to a double quoted
+ c-string with the path.
+ 2. Set an environment variable named IMAGE_DIFF_DIR with the path. This
+ takes precedence over the preprocessor macro to allow for run-time override.
+ 3. Keep everything unset, which will cause the failed image diff images to be saved
+ inside a temporary directory.
+ */
+#ifndef IMAGE_DIFF_DIR
+#define IMAGE_DIFF_DIR ""
+#endif
+
 /**
  Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
  @param view The view to snapshot
@@ -61,7 +75,7 @@
 
 #define FBSnapshotVerifyViewOrLayerWithOptions(what__, viewOrLayer__, identifier__, suffixes__, tolerance__) \
 { \
-  NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ tolerance:tolerance__ defaultReferenceDirectory:(@ FB_REFERENCE_IMAGE_DIR)]; \
+  NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ tolerance:tolerance__ defaultReferenceDirectory:(@ FB_REFERENCE_IMAGE_DIR) defaultImageDiffDirectory:(@ IMAGE_DIFF_DIR)]; \
   BOOL noErrors = (errorDescription == nil); \
   XCTAssertTrue(noErrors, @"%@", errorDescription); \
 }
@@ -138,18 +152,21 @@
  @param suffixes An NSOrderedSet of strings for the different suffixes
  @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
  @param defaultReferenceDirectory The directory to default to for reference images.
+ @param defaultImageDiffDirectory The directory to default to for failed image diffs.
  @returns nil if the comparison (or saving of the reference image) succeeded. Otherwise it contains an error description.
  */
 - (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
                              identifier:(NSString *)identifier
                                suffixes:(NSOrderedSet *)suffixes
                               tolerance:(CGFloat)tolerance
-              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory;
+              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
+              defaultImageDiffDirectory:(NSString *)defaultImageDiffDirectory;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.
  @param layer The Layer to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.
+ @param imageDiffDirectory The directory in which failed image diffs are stored.
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
  @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
@@ -157,6 +174,7 @@
  */
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer
       referenceImagesDirectory:(NSString *)referenceImagesDirectory
+            imageDiffDirectory:(NSString *)imageDiffDirectory
                     identifier:(NSString *)identifier
                      tolerance:(CGFloat)tolerance
                          error:(NSError **)errorPtr;
@@ -165,6 +183,7 @@
  Performs the comparison or records a snapshot of the view if recordMode is YES.
  @param view The view to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.
+ @param imageDiffDirectory The directory in which failed image diffs are stored.
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
  @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
@@ -172,6 +191,7 @@
  */
 - (BOOL)compareSnapshotOfView:(UIView *)view
      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+           imageDiffDirectory:(NSString *)imageDiffDirectory
                    identifier:(NSString *)identifier
                     tolerance:(CGFloat)tolerance
                         error:(NSError **)errorPtr;
@@ -192,8 +212,17 @@
 
  Helper function used to implement the assert macros.
 
- @param dir directory to use if environment variable not specified. Ignored if null or empty.
+ @param dir Directory to use if environment variable not specified. Ignored if null or empty.
  */
 - (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir;
+
+/**
+ Returns the failed image diff directory.
+
+ Helper function used to implement the assert macros.
+
+ @param dir Directory to use if environment variable not specified. Ignored if null or empty.
+ */
+- (NSString *)getImageDiffDirectoryWithDefault:(NSString *)dir;
 
 @end

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -80,9 +80,14 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
 /**
- The directory in which referfence images are stored.
+ The directory in which reference images are stored.
  */
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
+
+/**
+ The directory in which failed snapshot images are stored.
+ */
+@property (readwrite, nonatomic, copy) NSString *imageDiffDirectory;
 
 /**
  The name folder in which the snapshots will be saved for a given test case.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -259,11 +259,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:fileNameType];
-  NSString *folderPath = NSTemporaryDirectory();
-  if (getenv("IMAGE_DIFF_DIR")) {
-    folderPath = @(getenv("IMAGE_DIFF_DIR"));
-  }
-  NSString *filePath = [folderPath stringByAppendingPathComponent:self.folderName];
+
+  NSString *filePath = [_imageDiffDirectory stringByAppendingPathComponent:self.folderName];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -17,15 +17,17 @@ public extension FBSnapshotTestCase {
 
   private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), tolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: FB_REFERENCE_IMAGE_DIR)
+    let envImageDiffDirectory = self.getImageDiffDirectory(withDefault: IMAGE_DIFF_DIR)
     var error: NSError?
     var comparisonSuccess = false
 
-    if let envReferenceImageDirectory = envReferenceImageDirectory {
+    if let envReferenceImageDirectory = envReferenceImageDirectory, let envImageDiffDirectory = envImageDiffDirectory {
       for suffix in suffixes {
         let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
+        let imageDiffDirectory = envImageDiffDirectory
         if viewOrLayer.isKind(of: UIView.self) {
           do {
-            try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
+            try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, tolerance: tolerance)
             comparisonSuccess = true
           } catch let error1 as NSError {
             error = error1
@@ -33,7 +35,7 @@ public extension FBSnapshotTestCase {
           }
         } else if viewOrLayer.isKind(of: CALayer.self) {
           do {
-            try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
+            try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, tolerance: tolerance)
             comparisonSuccess = true
           } catch let error1 as NSError {
             error = error1

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
@@ -183,7 +183,6 @@
 				B30449181AB794320067C75D /* Frameworks */,
 				B30449191AB794320067C75D /* Resources */,
 				EB64CD802D89DDA691FA7827 /* [CP] Embed Pods Frameworks */,
-				30B7BE4963F35A6D89E72AFF /* [CP] Copy Pods Resources */,
 				185D9F73B9CAAE68941B87AB /* 📦 Embed Pods Frameworks */,
 				E1316CB9B2C08A51D1D31909 /* 📦 Copy Pods Resources */,
 			);
@@ -286,21 +285,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		30B7BE4963F35A6D89E72AFF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FBSnapshotTestCaseDemoTests/Pods-FBSnapshotTestCaseDemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E1316CB9B2C08A51D1D31909 /* 📦 Copy Pods Resources */ = {

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCaseDemo.xcscheme
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCaseDemo.xcscheme
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -88,6 +86,11 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IMAGE_DIFF_DIR"
+            value = "$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/FailedSnapshotImages"
+            isEnabled = "YES">
+         </EnvironmentVariable>
          <EnvironmentVariable
             key = "FB_REFERENCE_IMAGE_DIR"
             value = "$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages"

--- a/FBSnapshotTestCaseDemo/Podfile.lock
+++ b/FBSnapshotTestCaseDemo/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - iOSSnapshotTestCase (2.2.0):
-    - iOSSnapshotTestCase/SwiftSupport (= 2.2.0)
-  - iOSSnapshotTestCase/Core (2.2.0)
-  - iOSSnapshotTestCase/SwiftSupport (2.2.0):
+  - iOSSnapshotTestCase (3.1.0):
+    - iOSSnapshotTestCase/SwiftSupport (= 3.1.0)
+  - iOSSnapshotTestCase/Core (3.1.0)
+  - iOSSnapshotTestCase/SwiftSupport (3.1.0):
     - iOSSnapshotTestCase/Core
 
 DEPENDENCIES:
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   iOSSnapshotTestCase:
-    :path: ..
+    :path: ".."
 
 SPEC CHECKSUMS:
-  iOSSnapshotTestCase: 6acfc36526ee5be1f90f893396e9f0b69bc02f2b
+  iOSSnapshotTestCase: 037b2e86ebc1cea90a48578c364295cd853c24aa
 
 PODFILE CHECKSUM: 23fc15db0c3233d57acaa5dbafbc9f5f89f2f477
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installation with CocoaPods
 |`FB_REFERENCE_IMAGE_DIR`|`$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages`|
 |`IMAGE_DIFF_DIR`|`$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/FailureDiffs`|
 
-Define the `IMAGE_DIFF_DIR` to the directory where you want to store diffs of failed snapshots.
+Define the `IMAGE_DIFF_DIR` to the directory where you want to store diffs of failed snapshots. There are also [three ways](https://github.com/uber/ios-snapshot-test-case/blob/master/FBSnapshotTestCase/FBSnapshotTestCase.h#L34-L43) to set failed image diff directories.
 
 ![](FBSnapshotTestCaseDemo/Scheme_FB_REFERENCE_IMAGE_DIR.png)
 


### PR DESCRIPTION
This improves the support for `IMAGE_DIFF_DIR` by adding support for setting it as a preprocessor macro, as well as setting it on `FBSnapshotTestController`. Also refactors how this directory is passed around in the library to make it match how `FB_REFERENCE_IMAGE_DIR` works.