### PR TITLE
Remove deviceAgnostic, agnosticOptions, add new replacement called fileNameOptions

### DIFF
--- a/FBSnapshotTestCase.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCase.xcodeproj/project.pbxproj
@@ -151,9 +151,9 @@
 				B31987FF1AB782D100B0A900 /* Tests */,
 				B31987F11AB782D000B0A900 /* Products */,
 			);
-			indentWidth = 2;
+			indentWidth = 4;
 			sourceTree = "<group>";
-			tabWidth = 2;
+			tabWidth = 4;
 		};
 		B31987F11AB782D000B0A900 /* Products */ = {
 			isa = PBXGroup;

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -137,21 +137,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- When @c YES appends the name of the device model and OS to the snapshot file name.
- The default value is @c NO.
+ When set, allows fine-grained control over what you want the file names to include.
+
+ Allows you to combine which device or simulator specific details you want in your snapshot file names.
+
+ The default value is FBSnapshotTestCaseFileNameIncludeOptionScreenScale.
+
+ @discussion If you are migrating from the now deleted FBSnapshotTestCaseAgnosticOption to FBSnapshotTestCaseFileNameIncludeOption, we default to using FBSnapshotTestCaseFileNameIncludeOptionScreenScale for fileNameOptions to make the transition easy. If you don't want to have the screen scale included in your file name, you need to set fileNameOptions to a mask that doesn't include FBSnapshotTestCaseFileNameIncludeOptionScreenScale:
+
+ self.fileNameOptions = (FBSnapshotTestCaseFileNameIncludeOptionDevice | FBSnapshotTestCaseFileNameIncludeOptionOS);
  */
-@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic DEPRECATED_MSG_ATTRIBUTE("Use agnosticOptions instead. deviceAgnostic will be removed in a future version of iOS Snapshot Test Case.");
 
-/**
- When set, allows fine-grained control over how agnostic you want the file names to be.
-
- Allows you to combine which agnostic options you want in your snapshot file names.
-
- The default value is FBSnapshotTestCaseAgnosticOptionNone.
-
- @attention If deviceAgnostic is YES, this bitmask is ignored. deviceAgnostic will be deprecated in a future version of FBSnapshotTestCase.
- */
-@property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
+@property (readwrite, nonatomic, assign) FBSnapshotTestCaseFileNameIncludeOption fileNameOptions;
 
 /**
  Overrides the folder name in which the snapshot is going to be saved.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -39,26 +39,15 @@
     _snapshotController.recordMode = recordMode;
 }
 
-- (BOOL)isDeviceAgnostic
+- (FBSnapshotTestCaseFileNameIncludeOption)fileNameOptions
 {
-    return _snapshotController.deviceAgnostic;
+    return _snapshotController.fileNameOptions;
 }
 
-- (void)setDeviceAgnostic:(BOOL)deviceAgnostic
+- (void)setFileNameOptions:(FBSnapshotTestCaseFileNameIncludeOption)fileNameOptions
 {
     NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-    _snapshotController.deviceAgnostic = deviceAgnostic;
-}
-
-- (FBSnapshotTestCaseAgnosticOption)agnosticOptions
-{
-    return _snapshotController.agnosticOptions;
-}
-
-- (void)setAgnosticOptions:(FBSnapshotTestCaseAgnosticOption)agnosticOptions
-{
-    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-    _snapshotController.agnosticOptions = agnosticOptions;
+    _snapshotController.fileNameOptions = fileNameOptions;
 }
 
 - (BOOL)usesDrawViewHierarchyInRect

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -16,18 +16,20 @@ extern "C" {
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- An option mask that allows you to cherry pick which parts you want to 'be agnostic' in the snapshot file name.
+ An option mask that allows you to cherry pick which parts you want to include in the snapshot file name.
 
- - FBSnapshotTestCaseAgnosticOptionNone: Don't make the file name agnostic at all.
- - FBSnapshotTestCaseAgnosticOptionDevice: The file name should be agnostic on the device name, as returned by UIDevice.currentDevice.model.
- - FBSnapshotTestCaseAgnosticOptionOS: The file name should be agnostic on the OS version, as returned by UIDevice.currentDevice.systemVersion.
- - FBSnapshotTestCaseAgnosticOptionScreenSize: The file name should be agnostic on the screen size of the current keyWindow, as returned by UIApplication.sharedApplication.keyWindow.bounds.size.
+ - FBSnapshotTestCaseFileNameIncludeOptionNone: Don't include any of these options at all.
+ - FBSnapshotTestCaseFileNameIncludeOptionDevice: The file name should include the device name, as returned by UIDevice.currentDevice.model.
+ - FBSnapshotTestCaseFileNameIncludeOptionOS: The file name should include the OS version, as returned by UIDevice.currentDevice.systemVersion.
+ - FBSnapshotTestCaseFileNameIncludeOptionScreenSize: The file name should include the screen size of the current keyWindow, as returned by UIApplication.sharedApplication.keyWindow.bounds.size.
+ - FBSnapshotTestCaseFileNameIncludeOptionScreenScale: The file name should include the scale of the current device, as returned by UIScreen.mainScreen.scale.
  */
-typedef NS_OPTIONS(NSUInteger, FBSnapshotTestCaseAgnosticOption) {
-    FBSnapshotTestCaseAgnosticOptionNone = 1 << 0,
-    FBSnapshotTestCaseAgnosticOptionDevice = 1 << 1,
-    FBSnapshotTestCaseAgnosticOptionOS = 1 << 2,
-    FBSnapshotTestCaseAgnosticOptionScreenSize = 1 << 3
+typedef NS_OPTIONS(NSUInteger, FBSnapshotTestCaseFileNameIncludeOption) {
+  FBSnapshotTestCaseFileNameIncludeOptionNone = 1 << 0,
+  FBSnapshotTestCaseFileNameIncludeOptionDevice = 1 << 1,
+  FBSnapshotTestCaseFileNameIncludeOptionOS = 1 << 2,
+  FBSnapshotTestCaseFileNameIncludeOptionScreenSize = 1 << 3,
+  FBSnapshotTestCaseFileNameIncludeOptionScreenScale = 1 << 4
 };
 
 /**
@@ -48,21 +50,13 @@ BOOL FBSnapshotTestCaseIs64Bit(void);
 NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void);
 
 /**
- Returns a fully «normalized» file name.
- Strips punctuation and spaces and replaces them with @c _. Also appends the device model, running OS and screen size to the file name.
- 
- @returns An @c NSString object containing the passed @c fileName with the device model, OS and screen size appended at the end.
- */
-NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName);
-
-/**
  Returns a fully normalized file name as per the provided option mask. Strips punctuation and spaces and replaces them with @c _.
 
  @param fileName The file name to normalize.
- @param option Agnostic options to use before normalization.
- @return An @c NSString object containing the passed @c fileName and optionally, with the device model and/or OS and/or screen size appended at the end.
+ @param option File Name Include options to use before normalization.
+ @return An @c NSString object containing the passed @c fileName and optionally, with the device model and/or OS and/or screen size and/or screen scale appended at the end.
  */
-NSString *FBDeviceAgnosticNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseAgnosticOption option);
+NSString *FBFileNameIncludeNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseFileNameIncludeOption option);
 
 NS_ASSUME_NONNULL_END
 

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -30,38 +30,20 @@ NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void)
     return [suffixesSet copy];
 }
 
-NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName)
+NSString *FBFileNameIncludeNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseFileNameIncludeOption option)
 {
-    UIDevice *device = [UIDevice currentDevice];
-    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-    CGSize screenSize = keyWindow.bounds.size;
-    NSString *os = device.systemVersion;
-
-    fileName = [NSString stringWithFormat:@"%@_%@%@_%.0fx%.0f", fileName, device.model, os, screenSize.width, screenSize.height];
-
-    NSMutableCharacterSet *invalidCharacters = [NSMutableCharacterSet new];
-    [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
-    [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
-    NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
-    fileName = [validComponents componentsJoinedByString:@"_"];
-
-    return fileName;
-}
-
-NSString *FBDeviceAgnosticNormalizedFileNameFromOption(NSString *fileName, FBSnapshotTestCaseAgnosticOption option)
-{
-    if ((option & FBSnapshotTestCaseAgnosticOptionDevice) == FBSnapshotTestCaseAgnosticOptionDevice) {
+    if ((option & FBSnapshotTestCaseFileNameIncludeOptionDevice) == FBSnapshotTestCaseFileNameIncludeOptionDevice) {
         UIDevice *device = [UIDevice currentDevice];
         fileName = [fileName stringByAppendingFormat:@"_%@", device.model];
     }
 
-    if ((option & FBSnapshotTestCaseAgnosticOptionOS) == FBSnapshotTestCaseAgnosticOptionOS) {
+    if ((option & FBSnapshotTestCaseFileNameIncludeOptionOS) == FBSnapshotTestCaseFileNameIncludeOptionOS) {
         UIDevice *device = [UIDevice currentDevice];
         NSString *os = device.systemVersion;
         fileName = [fileName stringByAppendingFormat:@"_%@", os];
     }
 
-    if ((option & FBSnapshotTestCaseAgnosticOptionScreenSize) == FBSnapshotTestCaseAgnosticOptionScreenSize) {
+    if ((option & FBSnapshotTestCaseFileNameIncludeOptionScreenSize) == FBSnapshotTestCaseFileNameIncludeOptionScreenSize) {
         UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
         CGSize screenSize = keyWindow.bounds.size;
         fileName = [fileName stringByAppendingFormat:@"_%.0fx%.0f", screenSize.width, screenSize.height];
@@ -72,6 +54,11 @@ NSString *FBDeviceAgnosticNormalizedFileNameFromOption(NSString *fileName, FBSna
     [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
     NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
     fileName = [validComponents componentsJoinedByString:@"_"];
+    
+    if ((option & FBSnapshotTestCaseFileNameIncludeOptionScreenScale) == FBSnapshotTestCaseFileNameIncludeOptionScreenScale) {
+        CGFloat screenScale = [[UIScreen mainScreen] scale];
+        fileName = [fileName stringByAppendingFormat:@"@%.fx", screenScale];
+    }
 
     return fileName;
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -60,21 +60,17 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- When @c YES appends the name of the device model and OS to the snapshot file name.
- The default value is @c NO.
+ When set, allows fine-grained control over what you want the file names to include.
+
+ Allows you to combine which device or simulator specific details you want in your snapshot file names.
+
+ The default value is FBSnapshotTestCaseFileNameIncludeOptionScreenScale.
+
+ @discussion If you are migrating from the now deleted FBSnapshotTestCaseAgnosticOption to FBSnapshotTestCaseFileNameIncludeOption, we default to using FBSnapshotTestCaseFileNameIncludeOptionScreenScale for fileNameOptions to make the transition easier. If you don't want to have the screen scale included in your file name, you need to set fileNameOptions to a mask that doesn't include FBSnapshotTestCaseFileNameIncludeOptionScreenScale:
+
+ self.fileNameOptions = (FBSnapshotTestCaseFileNameIncludeOptionDevice | FBSnapshotTestCaseFileNameIncludeOptionOS);
  */
-@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
-
-/**
- When set, allows fine-grained control over how agnostic you want the file names to be.
-
- Allows you to combine which agnostic options you want in your snapshot file names.
-
- The default value is FBSnapshotTestCaseAgnosticOptionNone.
-
- @attention If deviceAgnostic is YES, this bitmask is ignored. deviceAgnostic will be deprecated in a future version of FBSnapshotTestCase.
- */
-@property (readwrite, nonatomic, assign) FBSnapshotTestCaseAgnosticOption agnosticOptions;
+@property (readwrite, nonatomic, assign) FBSnapshotTestCaseFileNameIncludeOption fileNameOptions;
 
 /**
  Uses drawViewHierarchyInRect:afterScreenUpdates: to draw the image instead of renderInContext:

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -38,8 +38,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 {
     if (self = [super init]) {
         _folderName = NSStringFromClass(testClass);
-        _deviceAgnostic = NO;
-        _agnosticOptions = FBSnapshotTestCaseAgnosticOptionNone;
+        _fileNameOptions = FBSnapshotTestCaseFileNameIncludeOptionScreenScale;
 
         _fileManager = [[NSFileManager alloc] init];
     }
@@ -257,16 +256,11 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
         fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
     }
 
-    BOOL noAgnosticOption = (self.agnosticOptions & FBSnapshotTestCaseAgnosticOptionNone) == FBSnapshotTestCaseAgnosticOptionNone;
-    if (self.isDeviceAgnostic) {
-        fileName = FBDeviceAgnosticNormalizedFileName(fileName);
-    } else if (!noAgnosticOption) {
-        fileName = FBDeviceAgnosticNormalizedFileNameFromOption(fileName, self.agnosticOptions);
+    BOOL noFileNameOption = (self.fileNameOptions & FBSnapshotTestCaseFileNameIncludeOptionNone) == FBSnapshotTestCaseFileNameIncludeOptionNone;
+    if (!noFileNameOption) {
+      fileName = FBFileNameIncludeNormalizedFileNameFromOption(fileName, self.fileNameOptions);
     }
 
-    if ([[UIScreen mainScreen] scale] > 1) {
-        fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
-    }
     fileName = [fileName stringByAppendingPathExtension:@"png"];
     return fileName;
 }

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
@@ -91,9 +91,9 @@
 				0CC44285F6C476327AB77B9C /* Pods */,
 				8F54C791A73198B06F3A32A6 /* Frameworks */,
 			);
-			indentWidth = 2;
+			indentWidth = 4;
 			sourceTree = "<group>";
-			tabWidth = 2;
+			tabWidth = 4;
 		};
 		B30449031AB794320067C75D /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
We wanted to simply deprecate `agnosticOptions` and add `fileNameOptions` in a non–breaking way, but it made the implementation a bit too difficult. So if you're here trying to figure out where `agnosticOptions` went, we renamed it to `fileNameOptions`. Screen Scale is now part of the file options mask, so if you want to remove screen scale from your file names you can do so.

Fixes #30 
Fixes #52