### PR TITLE
Return the correct message when running tests in recordMode

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -156,11 +156,12 @@
         }
     }
 
+    if (self.recordMode) {
+      return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
+    }
+  
     if (!testSuccess) {
         return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
-    }
-    if (self.recordMode) {
-        return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
     }
 
     return nil;


### PR DESCRIPTION
When running the tests in record mode, they fail with the message: `Snapshot comparison failed: (null)` because it was checking for the test result before checking if the test ran in `recordMode`. This PR changes the validation order.