### PR TITLE
Use UIScreen over keyWindow to get size, so that size can be used without host application

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  - FBSnapshotTestCaseFileNameIncludeOptionNone: Don't include any of these options at all.
  - FBSnapshotTestCaseFileNameIncludeOptionDevice: The file name should include the device name, as returned by UIDevice.currentDevice.model.
  - FBSnapshotTestCaseFileNameIncludeOptionOS: The file name should include the OS version, as returned by UIDevice.currentDevice.systemVersion.
- - FBSnapshotTestCaseFileNameIncludeOptionScreenSize: The file name should include the screen size of the current keyWindow, as returned by UIApplication.sharedApplication.keyWindow.bounds.size.
+ - FBSnapshotTestCaseFileNameIncludeOptionScreenSize: The file name should include the screen size of the current device, as returned by UIScreen.mainScreen.bounds.size.
  - FBSnapshotTestCaseFileNameIncludeOptionScreenScale: The file name should include the scale of the current device, as returned by UIScreen.mainScreen.scale.
  */
 typedef NS_OPTIONS(NSUInteger, FBSnapshotTestCaseFileNameIncludeOption) {

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -44,8 +44,7 @@ NSString *FBFileNameIncludeNormalizedFileNameFromOption(NSString *fileName, FBSn
     }
 
     if ((option & FBSnapshotTestCaseFileNameIncludeOptionScreenSize) == FBSnapshotTestCaseFileNameIncludeOptionScreenSize) {
-        UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-        CGSize screenSize = keyWindow.bounds.size;
+        CGSize screenSize = [UIScreen mainScreen].bounds.size;
         fileName = [fileName stringByAppendingFormat:@"_%.0fx%.0f", screenSize.width, screenSize.height];
     }
 

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -148,7 +148,7 @@
     XCTAssertTrue([filePath containsString:allOptionsIncludedReferencePath]);
     
     // Manually constructing expected filePath to make sure it looks correct
-    NSString *expectedFilePath = [NSString stringWithFormat:@"%@%@_%@_%@_%.0fx%.0f@%.fx.png", referenceImagesDirectory, NSStringFromSelector(selector), [UIDevice currentDevice].model, [[UIDevice currentDevice].systemVersion stringByReplacingOccurrencesOfString:@"." withString:@"_"], [[UIApplication sharedApplication] keyWindow].bounds.size.width, [[UIApplication sharedApplication] keyWindow].bounds.size.height, [[UIScreen mainScreen] scale]];
+    NSString *expectedFilePath = [NSString stringWithFormat:@"%@%@_%@_%@_%.0fx%.0f@%.fx.png", referenceImagesDirectory, NSStringFromSelector(selector), [UIDevice currentDevice].model, [[UIDevice currentDevice].systemVersion stringByReplacingOccurrencesOfString:@"." withString:@"_"], [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height, [[UIScreen mainScreen] scale]];
     XCTAssertEqualObjects(expectedFilePath, filePath);
 }
 


### PR DESCRIPTION
Before without a host app the keyWindow would be nil, resulting in the screen size being reported as "0x0", now the size will be correct.