### PR TITLE
Added support for Xcode 9 attachments.

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -14,6 +14,7 @@
 #import <FBSnapshotTestCase/UIImage+Snapshot.h>
 
 #import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
 
 NSString *const FBSnapshotTestControllerErrorDomain = @"FBSnapshotTestControllerErrorDomain";
 NSString *const FBReferenceImageFilePathKey = @"FBReferenceImageFilePathKey";
@@ -181,6 +182,23 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                       identifier:(NSString *)identifier
                            error:(NSError **)errorPtr
 {
+    UIImage *diffImage = [referenceImage fb_diffWithImage:testImage];
+
+    [XCTContext runActivityNamed:identifier ?: NSStringFromSelector(selector) block:^(id<XCTActivity> _Nonnull activity) {
+        XCTAttachment *referenceAttachment = [XCTAttachment attachmentWithImage:referenceImage];
+        referenceAttachment.name = @"Reference Image";
+
+        XCTAttachment *failedAttachment = [XCTAttachment attachmentWithImage:testImage];
+        failedAttachment.name = @"Failed Image";
+
+        XCTAttachment *diffAttachment = [XCTAttachment attachmentWithImage:diffImage];
+        diffAttachment.name = @"Diffed Image";
+
+        [activity addAttachment:referenceAttachment];
+        [activity addAttachment:failedAttachment];
+        [activity addAttachment:diffAttachment];
+    }];
+
     NSData *referencePNGData = UIImagePNGRepresentation(referenceImage);
     NSData *testPNGData = UIImagePNGRepresentation(testImage);
 
@@ -216,7 +234,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                                                identifier:identifier
                                              fileNameType:FBTestSnapshotFileNameTypeFailedTestDiff];
 
-    UIImage *diffImage = [referenceImage fb_diffWithImage:testImage];
     NSData *diffImageData = UIImagePNGRepresentation(diffImage);
 
     if (![diffImageData writeToFile:diffPath options:NSDataWritingAtomic error:errorPtr]) {
@@ -317,6 +334,13 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                                error:(NSError **)errorPtr
 {
     UIImage *snapshot = [self _imageForViewOrLayer:viewOrLayer];
+
+    [XCTContext runActivityNamed:identifier ?: NSStringFromSelector(selector) block:^(id<XCTActivity> _Nonnull activity) {
+        XCTAttachment *recordedAttachment = [XCTAttachment attachmentWithImage:snapshot];
+        recordedAttachment.name = @"Recorded Image";
+        [activity addAttachment:recordedAttachment];
+    }];
+
     return [self _saveReferenceImage:snapshot selector:selector identifier:identifier error:errorPtr];
 }
 

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -8,15 +8,15 @@
  */
 
 public extension FBSnapshotTestCase {
-    func FBSnapshotVerifyView(_ view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+    func FBSnapshotVerifyView(_ view: UIView, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
 
-    func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+    func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
 
-  private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+  private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: FB_REFERENCE_IMAGE_DIR)
     let envImageDiffDirectory = self.getImageDiffDirectory(withDefault: IMAGE_DIFF_DIR)
     var error: NSError?


### PR DESCRIPTION
There are four separate PRs (https://github.com/uber/ios-snapshot-test-case/pull/83/, https://github.com/uber/ios-snapshot-test-case/pull/71, https://github.com/uber/ios-snapshot-test-case/pull/84, https://github.com/uber/ios-snapshot-test-case/pull/19) that have attempted to add this feature. Rather than pick a single PR and ask the contributor to update it to sync all of the functionality we decided we would do it ourselves to get this feature out as soon as possible. Thank you @mdiep, @niilohlin, @danieltmbr and @delebedev for your hard work and again I apologize for how long it has taken us to address this.

Across the four PRs there were three unique pieces of functionality that had to be added:
1. Create an `XCTActivity` so the attachments can be grouped together for easy inspection.
2. Attach the reference, failed and diffed images when a test fails.
3. Attach the recorded image when the tests are run in record mode.

Below are some screenshots to show what Xcode looks like for these scenarios:

**Failed Tests**
<img width="757" alt="failed" src="https://user-images.githubusercontent.com/535202/59882921-614f9c80-9368-11e9-90a6-0bc76313030b.png">
**Record Mode**
<img width="765" alt="recorded" src="https://user-images.githubusercontent.com/535202/59882922-614f9c80-9368-11e9-82b0-dc8b0f5ecca1.png">
