### PR TITLE
Moved record mode error up to ensure that it always early exits

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -115,7 +115,6 @@
         return [NSString stringWithFormat:@"Suffixes set cannot be empty %@", suffixes];
     }
 
-    BOOL testSuccess = NO;
     NSError *error = nil;
     NSMutableArray *errors = [NSMutableArray array];
 
@@ -125,7 +124,10 @@
         if (!referenceImageSaved) {
             [errors addObject:error];
         }
+
+        return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
     } else {
+        BOOL testSuccess = NO;
         for (NSString *suffix in suffixes) {
             NSString *referenceImagesDirectory = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffix];
             BOOL referenceImageAvailable = [self referenceImageRecordedInDirectory:referenceImagesDirectory identifier:(identifier) error:&error];
@@ -143,17 +145,13 @@
                 [errors addObject:error];
             }
         }
-    }
 
-    if (self.recordMode) {
-      return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
+        if (!testSuccess) {
+            return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
+        } else {
+            return nil;
+        }
     }
-  
-    if (!testSuccess) {
-        return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
-    }
-
-    return nil;
 }
 
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer


### PR DESCRIPTION
A minor follow up to https://github.com/uber/ios-snapshot-test-case/pull/65 that cleans the control flow up a little bit.