### PR TITLE
Fixed scale-agnostic image size comparison

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Compare.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Compare.m
@@ -46,10 +46,9 @@ typedef union {
 
 - (BOOL)fb_compareWithImage:(UIImage *)image perPixelTolerance:(CGFloat)perPixelTolerance overallTolerance:(CGFloat)overallTolerance
 {
-    NSAssert(CGSizeEqualToSize(self.size, image.size), @"Images must be same size.");
-
     CGSize referenceImageSize = CGSizeMake(CGImageGetWidth(self.CGImage), CGImageGetHeight(self.CGImage));
     CGSize imageSize = CGSizeMake(CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage));
+    NSAssert(CGSizeEqualToSize(referenceImageSize, imageSize), @"Images must be same size.");
 
     // The images have the equal size, so we could use the smallest amount of bytes because of byte padding
     size_t minBytesPerRow = MIN(CGImageGetBytesPerRow(self.CGImage), CGImageGetBytesPerRow(image.CGImage));

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -153,14 +153,17 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
              overallTolerance:(CGFloat)overallTolerance
                         error:(NSError **)errorPtr
 {
-    BOOL sameImageDimensions = CGSizeEqualToSize(referenceImage.size, image.size);
+    CGSize referenceImageSize = CGSizeMake(CGImageGetWidth(referenceImage.CGImage), CGImageGetHeight(referenceImage.CGImage));
+    CGSize imageSize = CGSizeMake(CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage));
+
+    BOOL sameImageDimensions = CGSizeEqualToSize(referenceImageSize, imageSize);
     if (sameImageDimensions && [referenceImage fb_compareWithImage:image perPixelTolerance:perPixelTolerance overallTolerance:overallTolerance]) {
         return YES;
     }
 
     if (errorPtr != NULL) {
         NSString *errorDescription = sameImageDimensions ? @"Images different" : @"Images different sizes";
-        NSString *errorReason = sameImageDimensions ? [NSString stringWithFormat:@"image pixels differed by more than %.2f%% from the reference image", overallTolerance * 100] : [NSString stringWithFormat:@"referenceImage:%@, image:%@", NSStringFromCGSize(referenceImage.size), NSStringFromCGSize(image.size)];
+        NSString *errorReason = sameImageDimensions ? [NSString stringWithFormat:@"image pixels differed by more than %.2f%% from the reference image", overallTolerance * 100] : [NSString stringWithFormat:@"referenceImage:%@, image:%@", NSStringFromCGSize(referenceImageSize), NSStringFromCGSize(imageSize)];
         FBSnapshotTestControllerErrorCode errorCode = sameImageDimensions ? FBSnapshotTestControllerErrorCodeImagesDifferent : FBSnapshotTestControllerErrorCodeImagesDifferentSizes;
 
         *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain


### PR DESCRIPTION
Previously the code would compare UIImage size properties, which are not in pixel units but scale-dependent points.
This would cause issue if a test uses reference images generated using .none fileNameOptions and ran tests on 2x or 3x simulators: they would fail early because of the size comparison because of the scale difference.

This commit changes the logic to use CGImageGet{Width,Height} instead, which returns the actual pixel size (akin to use size * scale).
This change makes sense since the image comparison code actually uses CGImage pixel retrieving methods.