### PR TITLE
Add convenience FBSnapshotVerifyViewController() function to Swift clients

### DIFF
--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -11,6 +11,14 @@ public extension FBSnapshotTestCase {
     func FBSnapshotVerifyView(_ view: UIView, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
+  
+    func FBSnapshotVerifyViewController(_ viewController: UIViewController, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+    viewController.view.bounds = UIScreen.main.bounds
+    viewController.viewWillAppear(false)
+    viewController.viewDidAppear(false)
+
+    FBSnapshotVerifyView(viewController.view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
+  }
 
     func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)


### PR DESCRIPTION
It is becoming more common to configure `UIViewController`s with view models and snapshot them. `ios-snapshot-test-case` is a great tool for this, but unfortunately it doesn't support for this 'out of the box'. This task is slightly more complicated than `FBSnapshotVerifyView(viewController.view)` since one almost always want to ensure the size of the view controller prior to the snapshot (and since some view controllers do layout adjustments in `viewWillAppear()/viewDidAppear()`, it is convenient to invoke those as well).

I've seen the pattern in this PR adopted in a few large projects which extensively use `ios-snapshot-test-case`. Since it is common, it would be great to have it built in to the library for everyone. Thoughts?

cc @efirestone @nickentin