### PR TITLE
Highlight different pixels

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Compare.h
+++ b/FBSnapshotTestCase/Categories/UIImage+Compare.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param overallTolerance The overall percentage of pixels that are allowed to change from the pixels in the reference image.
  @return A BOOL which represents if the image is the same or not.
  */
-- (BOOL)fb_compareWithImage:(UIImage *)image perPixelTolerance:(CGFloat)perPixelTolerance overallTolerance:(CGFloat)overallTolerance;
+- (BOOL)fb_compareWithImage:(UIImage *)image perPixelTolerance:(CGFloat)perPixelTolerance overallTolerance:(CGFloat)overallTolerance differentPixels:(NSMutableArray **)differentPixels;
 
 @end
 

--- a/FBSnapshotTestCase/Categories/UIImage+Diff.h
+++ b/FBSnapshotTestCase/Categories/UIImage+Diff.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIImage (Diff)
 
-- (UIImage *)fb_diffWithImage:(UIImage *)image;
+- (UIImage *)fb_diffWithImage:(UIImage *)image differentPixels:(NSArray *)differentPixels;
 
 @end
 

--- a/FBSnapshotTestCase/Categories/UIImage+Diff.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Diff.m
@@ -32,7 +32,7 @@
 
 @implementation UIImage (Diff)
 
-- (UIImage *)fb_diffWithImage:(UIImage *)image
+- (UIImage *)fb_diffWithImage:(UIImage *)image differentPixels:(NSArray *)differentPixels
 {
     if (!image) {
         return nil;
@@ -48,6 +48,20 @@
     CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
     CGContextFillRect(context, CGRectMake(0, 0, self.size.width, self.size.height));
     CGContextEndTransparencyLayer(context);
+    
+    if (differentPixels) {
+        CGContextSetFillColorWithColor(context, [UIColor redColor].CGColor);
+        
+        CGFloat screenScale = [[UIScreen mainScreen] scale];
+        const NSUInteger pixelCount = differentPixels.count;
+        for (NSUInteger n = 0; n < pixelCount; ++n) {
+            int pixelNumber = [differentPixels[n] intValue] / screenScale;
+            CGFloat x = (pixelNumber % ((int) roundf(self.size.width)));
+            CGFloat y = ((pixelNumber - x) / (self.size.width * screenScale));
+
+            CGContextFillRect(context, CGRectMake(x, y, 1, 1));
+        }
+    }
     UIImage *returnImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return returnImage;

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -137,6 +137,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ When YES, will cause hightlighting different fixels on test failure.
+ */
+@property (readwrite, nonatomic, assign) BOOL highlightDifferentPixels;
+
+/**
  When set, allows fine-grained control over what you want the file names to include.
 
  Allows you to combine which device or simulator specific details you want in your snapshot file names.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -39,6 +39,17 @@
     _snapshotController.recordMode = recordMode;
 }
 
+- (BOOL)highlightDifferentPixels
+{
+    return _snapshotController.highlightDifferentPixels;
+}
+
+- (void)setHighlightDifferentPixels:(BOOL)highlightDifferentPixels
+{
+    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+    _snapshotController.highlightDifferentPixels = highlightDifferentPixels;
+}
+
 - (FBSnapshotTestCaseFileNameIncludeOption)fileNameOptions
 {
     return _snapshotController.fileNameOptions;

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -60,6 +60,11 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ Highlight Different Pixels.
+ */
+@property (readwrite, nonatomic, assign) BOOL highlightDifferentPixels;
+
+/**
  When set, allows fine-grained control over what you want the file names to include.
 
  Allows you to combine which device or simulator specific details you want in your snapshot file names.
@@ -173,12 +178,15 @@ extern NSString *const FBDiffedImageKey;
  @param image The image to test against the reference.
  @param overallTolerance The percentage of pixels that can differ and still be considered 'identical'.
  @param errorPtr An error that indicates why the comparison failed if it does.
+ @param differentPixels An array of different pixel numbers.
  @returns YES if the comparison succeeded and the images are the same(ish).
  */
 - (BOOL)compareReferenceImage:(UIImage *)referenceImage
                       toImage:(UIImage *)image
              overallTolerance:(CGFloat)overallTolerance
-                        error:(NSError **)errorPtr;
+                        error:(NSError **)errorPtr
+              differentPixels:(NSMutableArray **)differentPixels
+;
 
 /**
  Performs a pixel-by-pixel comparison of the two images with an allowable margin of error.
@@ -187,13 +195,15 @@ extern NSString *const FBDiffedImageKey;
  @param perPixelTolerance The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'.
  @param overallTolerance The percentage of pixels that can differ and still be considered 'identical'.
  @param errorPtr An error that indicates why the comparison failed if it does.
+ @param differentPixels An array of different pixel numbers.
  @returns YES if the comparison succeeded and the images are the same(ish).
  */
 - (BOOL)compareReferenceImage:(UIImage *)referenceImage
                       toImage:(UIImage *)image
             perPixelTolerance:(CGFloat)perPixelTolerance
              overallTolerance:(CGFloat)overallTolerance
-                        error:(NSError **)errorPtr;
+                        error:(NSError **)errorPtr
+              differentPixels:(NSMutableArray **)differentPixels;
 
 /**
  Saves the reference image and the test image to `failedOutputDirectory`.
@@ -208,7 +218,8 @@ extern NSString *const FBDiffedImageKey;
                        testImage:(UIImage *)testImage
                         selector:(SEL)selector
                       identifier:(nullable NSString *)identifier
-                           error:(NSError **)errorPtr;
+                           error:(NSError **)errorPtr
+                 differentPixels:(NSArray *)differentPixels;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -29,7 +29,8 @@
     id testClass = nil;
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     NSError *error = nil;
-    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error differentPixels:&differentPixels]);
     XCTAssertNil(error);
 }
 
@@ -43,7 +44,8 @@
     id testClass = nil;
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     NSError *error = nil;
-    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error differentPixels:&differentPixels]);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, FBSnapshotTestControllerErrorCodeImagesDifferent);
 }
@@ -59,7 +61,8 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     // With virtually no margin for error, this should fail to be equal
     NSError *error = nil;
-    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:.0001 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:.0001 error:&error differentPixels:&differentPixels]);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, FBSnapshotTestControllerErrorCodeImagesDifferent);
 }
@@ -75,7 +78,8 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     // With some tolerance these should be considered the same
     NSError *error = nil;
-    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:.001 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:.001 error:&error differentPixels:&differentPixels]);
     XCTAssertNil(error);
 }
 
@@ -90,7 +94,8 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     // With some tolerance these should be considered the same
     NSError *error = nil;
-    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage overallTolerance:0 error:&error differentPixels:&differentPixels]);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, FBSnapshotTestControllerErrorCodeImagesDifferentSizes);
 }
@@ -170,7 +175,8 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     // With virtually no margin for error, this should fail to be equal
     NSError *error = nil;
-    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage perPixelTolerance:.06 overallTolerance:0 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage perPixelTolerance:.06 overallTolerance:0 error:&error differentPixels:&differentPixels]);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, FBSnapshotTestControllerErrorCodeImagesDifferent);
 }
@@ -186,7 +192,8 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:testClass];
     // With some tolerance these should be considered the same
     NSError *error = nil;
-    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage perPixelTolerance:.06 overallTolerance:0 error:&error]);
+    NSMutableArray *differentPixels = nil;
+    XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage perPixelTolerance:.06 overallTolerance:0 error:&error differentPixels:&differentPixels]);
     XCTAssertNil(error);
 }
 


### PR DESCRIPTION
When perPixelTolerance == 0 is used library sometimes produce not representable diffs([example](https://user-images.githubusercontent.com/7813723/67786886-ad31f100-fa80-11e9-8703-83daa6e42e4a.png))

It happens because of used kCGBlendModeDifference for generating diff images and it's implementation are not very precise.

For such situations I implemented highlightDifferentPixels property of FBSnapshotTestCase which when is true acitivate producing of diff image with highlighted pixels [(example)](https://user-images.githubusercontent.com/7813723/67787005-dfdbe980-fa80-11e9-8055-c439ceebcc84.png).

```
class AnyTestCase: FBSnapshotTestCase {
    override func setUp() {
        super.setUp()

        recordMode = false
        highlightDifferentPixels = true
    }
}
```

![Diffed Image_3_72E6C59B-DBF7-432D-84D3-5F9270F32F13](https://user-images.githubusercontent.com/7813723/67786886-ad31f100-fa80-11e9-8703-83daa6e42e4a.png)

![Failed Image_2_72E6C59B-DBF7-432D-84D3-5F9270F32F13](https://user-images.githubusercontent.com/7813723/67786887-ad31f100-fa80-11e9-823e-1535a00076b1.png)

![Reference Image_1_72E6C59B-DBF7-432D-84D3-5F9270F32F13](https://user-images.githubusercontent.com/7813723/67786889-adca8780-fa80-11e9-81f6-823378e5364b.png)

![Diffed Image vs Highlighted Pixels](https://user-images.githubusercontent.com/7813723/67787005-dfdbe980-fa80-11e9-8055-c439ceebcc84.png)
