### PR TITLE
Allow iOSSnapshotTestsCase Bazel builds

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Compare.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Compare.m
@@ -28,7 +28,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <FBSnapshotTestCase/UIImage+Compare.h>
+#import "FBSnapshotTestCase/UIImage+Compare.h"
 
 // This makes debugging much more fun
 typedef union {

--- a/FBSnapshotTestCase/Categories/UIImage+Diff.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Diff.m
@@ -28,7 +28,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <FBSnapshotTestCase/UIImage+Diff.h>
+#import "FBSnapshotTestCase/UIImage+Diff.h"
 
 @implementation UIImage (Diff)
 

--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
@@ -7,7 +7,7 @@
  *
  */
 
-#import <FBSnapshotTestCase/UIImage+Snapshot.h>
+#import "FBSnapshotTestCase/UIImage+Snapshot.h"
 
 @implementation UIImage (Snapshot)
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -7,8 +7,8 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
-#import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h"
+#import "FBSnapshotTestCase/FBSnapshotTestController.h"
 
 #import <QuartzCore/QuartzCore.h>
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -7,8 +7,8 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCase.h>
-#import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCase.h"
+#import "FBSnapshotTestCase/FBSnapshotTestController.h"
 
 @implementation FBSnapshotTestCase {
     FBSnapshotTestController *_snapshotController;

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -7,7 +7,7 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h"
 #import <UIKit/UIKit.h>
 
 BOOL FBSnapshotTestCaseIs64Bit(void)

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -7,11 +7,11 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
-#import <FBSnapshotTestCase/FBSnapshotTestController.h>
-#import <FBSnapshotTestCase/UIImage+Compare.h>
-#import <FBSnapshotTestCase/UIImage+Diff.h>
-#import <FBSnapshotTestCase/UIImage+Snapshot.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCasePlatform.h"
+#import "FBSnapshotTestCase/FBSnapshotTestController.h"
+#import "FBSnapshotTestCase/UIImage+Compare.h"
+#import "FBSnapshotTestCase/UIImage+Diff.h"
+#import "FBSnapshotTestCase/UIImage+Snapshot.h"
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -7,7 +7,7 @@
  *
  */
 
- import FBSnapshotTestCase
+import FBSnapshotTestCase
 
 public extension FBSnapshotTestCase {
     func FBSnapshotVerifyView(_ view: UIView, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -7,11 +7,13 @@
  *
  */
 
+ import FBSnapshotTestCase
+
 public extension FBSnapshotTestCase {
     func FBSnapshotVerifyView(_ view: UIView, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
-  
+
     func FBSnapshotVerifyViewController(_ viewController: UIViewController, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     viewController.view.bounds = UIScreen.main.bounds
     viewController.viewWillAppear(false)

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseDemoTests.m
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseDemoTests.m
@@ -7,7 +7,7 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCase.h>
+#import "FBSnapshotTestCase/FBSnapshotTestCase.h"
 
 @interface FBSnapshotTestCaseDemoTests : FBSnapshotTestCase
 


### PR DESCRIPTION
Changes that allow iOSSnapshotTestsCase to be built with the following Bazel BUILD file:

```
load(
    "@build_bazel_rules_swift//swift:swift.bzl",
    "swift_library",
)

objc_library(
    name = "FBSnapshotTestCase",
    module_name = "FBSnapshotTestCase",
    srcs = glob(["FBSnapshotTestCase/**/*.{h,m}"]),
    hdrs = glob(["FBSnapshotTestCase/**/*.h"])
)

swift_library(
    name = "iOSSnapshotTestCase",
    module_name = "iOSSnapshotTestCase",
    srcs = glob(["FBSnapshotTestCase/**/*.swift"]),
    deps = [
        ":FBSnapshotTestCase"
    ]
)
```