### PR TITLE
Add UIImage parameter to FBSnapshotVerify function.

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -53,7 +53,7 @@
  @param tolerance The overall percentage of pixels that can differ and still count as an 'identical' view.
  */
 #define FBSnapshotVerifyViewWithOptions(view__, identifier__, suffixes__, tolerance__) \
-    FBSnapshotVerifyViewOrLayerWithOptions(View, view__, identifier__, suffixes__, tolerance__)
+    FBSnapshotVerifyViewOrLayerOrImageWithOptions(View, view__, identifier__, suffixes__, tolerance__)
 
 /**
  Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
@@ -64,7 +64,7 @@
  @param tolerance The overall percentage of pixels that can differ and still count as an 'identical' layer.
  */
 #define FBSnapshotVerifyViewWithPixelOptions(view__, identifier__, suffixes__, pixelTolerance__, tolerance__) \
-    FBSnapshotVerifyViewOrLayerWithPixelOptions(View, view__, identifier__, suffixes__, pixelTolerance__, tolerance__)
+    FBSnapshotVerifyViewOrLayerOrImageWithPixelOptions(View, view__, identifier__, suffixes__, pixelTolerance__, tolerance__)
 
 #define FBSnapshotVerifyView(view__, identifier__) \
     FBSnapshotVerifyViewWithOptions(view__, identifier__, FBSnapshotTestCaseDefaultSuffixes(), 0)
@@ -79,7 +79,7 @@
  @param tolerance The overall percentage of pixels that can differ and still count as an 'identical' layer.
  */
 #define FBSnapshotVerifyLayerWithPixelOptions(layer__, identifier__, suffixes__, pixelTolerance__, tolerance__) \
-    FBSnapshotVerifyViewOrLayerWithPixelOptions(Layer, layer__, identifier__, suffixes__, pixelTolerance__, tolerance__)
+    FBSnapshotVerifyViewOrLayerOrImageWithPixelOptions(Layer, layer__, identifier__, suffixes__, pixelTolerance__, tolerance__)
 
 /**
  Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
@@ -89,21 +89,21 @@
  @param tolerance The overall percentage of pixels that can differ and still count as an 'identical' layer.
  */
 #define FBSnapshotVerifyLayerWithOptions(layer__, identifier__, suffixes__, tolerance__) \
-    FBSnapshotVerifyViewOrLayerWithOptions(Layer, layer__, identifier__, suffixes__, tolerance__)
+    FBSnapshotVerifyViewOrLayerOrImageWithOptions(Layer, layer__, identifier__, suffixes__, tolerance__)
 
 #define FBSnapshotVerifyLayer(layer__, identifier__) \
     FBSnapshotVerifyLayerWithOptions(layer__, identifier__, FBSnapshotTestCaseDefaultSuffixes(), 0)
 
-#define FBSnapshotVerifyViewOrLayerWithOptions(what__, viewOrLayer__, identifier__, suffixes__, tolerance__)                                                                                                                                           \
+#define FBSnapshotVerifyViewOrLayerOrImageWithOptions(what__, viewOrLayerOrImage__, identifier__, suffixes__, tolerance__)                                                                                                                                           \
     {                                                                                                                                                                                                                                                  \
-        NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ overallTolerance:tolerance__ defaultReferenceDirectory:(@FB_REFERENCE_IMAGE_DIR) defaultImageDiffDirectory:(@IMAGE_DIFF_DIR)]; \
+        NSString *errorDescription = [self snapshotVerifyViewOrLayerOrImage:viewOrLayerOrImage__ identifier:identifier__ suffixes:suffixes__ overallTolerance:tolerance__ defaultReferenceDirectory:(@FB_REFERENCE_IMAGE_DIR) defaultImageDiffDirectory:(@IMAGE_DIFF_DIR)]; \
         BOOL noErrors = (errorDescription == nil);                                                                                                                                                                                                     \
         XCTAssertTrue(noErrors, @"%@", errorDescription);                                                                                                                                                                                              \
     }
 
-#define FBSnapshotVerifyViewOrLayerWithPixelOptions(what__, viewOrLayer__, identifier__, suffixes__, pixelTolerance__, tolerance__)                                                                                                                                                    \
+#define FBSnapshotVerifyViewOrLayerOrImageWithPixelOptions(what__, viewOrLayerOrImage__, identifier__, suffixes__, pixelTolerance__, tolerance__)                                                                                                                                                    \
     {                                                                                                                                                                                                                                                                                  \
-        NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ perPixelTolerance:pixelTolerance__ overallTolerance:tolerance__ defaultReferenceDirectory:(@FB_REFERENCE_IMAGE_DIR) defaultImageDiffDirectory:(@IMAGE_DIFF_DIR)]; \
+        NSString *errorDescription = [self snapshotVerifyViewOrLayerOrImage:viewOrLayerOrImage__ identifier:identifier__ suffixes:suffixes__ perPixelTolerance:pixelTolerance__ overallTolerance:tolerance__ defaultReferenceDirectory:(@FB_REFERENCE_IMAGE_DIR) defaultImageDiffDirectory:(@IMAGE_DIFF_DIR)]; \
         BOOL noErrors = (errorDescription == nil);                                                                                                                                                                                                                                     \
         XCTAssertTrue(noErrors, @"%@", errorDescription);                                                                                                                                                                                                                              \
     }
@@ -173,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.
- @param viewOrLayer The UIView or CALayer to snapshot.
+ @param viewOrLayerOrImage The UIView or CALayer to snapshot.
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
  @param suffixes An NSOrderedSet of strings for the different suffixes.
  @param overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
@@ -181,16 +181,16 @@ NS_ASSUME_NONNULL_BEGIN
  @param defaultImageDiffDirectory The directory to default to for failed image diffs.
  @returns nil if the comparison (or saving of the reference image) succeeded. Otherwise it contains an error description.
  */
-- (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
-                             identifier:(nullable NSString *)identifier
-                               suffixes:(NSOrderedSet *)suffixes
-                       overallTolerance:(CGFloat)overallTolerance
-              defaultReferenceDirectory:(nullable NSString *)defaultReferenceDirectory
-              defaultImageDiffDirectory:(nullable NSString *)defaultImageDiffDirectory;
+- (NSString *)snapshotVerifyViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                    identifier:(nullable NSString *)identifier
+                                      suffixes:(NSOrderedSet *)suffixes
+                              overallTolerance:(CGFloat)overallTolerance
+                     defaultReferenceDirectory:(nullable NSString *)defaultReferenceDirectory
+                     defaultImageDiffDirectory:(nullable NSString *)defaultImageDiffDirectory;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.
- @param viewOrLayer The UIView or CALayer to snapshot.
+ @param viewOrLayerOrImage The UIView or CALayer to snapshot.
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
  @param suffixes An NSOrderedSet of strings for the different suffixes.
  @param perPixelTolerance The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
@@ -199,13 +199,13 @@ NS_ASSUME_NONNULL_BEGIN
  @param defaultImageDiffDirectory The directory to default to for failed image diffs.
  @returns nil if the comparison (or saving of the reference image) succeeded. Otherwise it contains an error description.
  */
-- (nullable NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
-                                      identifier:(nullable NSString *)identifier
-                                        suffixes:(NSOrderedSet *)suffixes
-                               perPixelTolerance:(CGFloat)perPixelTolerance
-                                overallTolerance:(CGFloat)overallTolerance
-                       defaultReferenceDirectory:(nullable NSString *)defaultReferenceDirectory
-                       defaultImageDiffDirectory:(nullable NSString *)defaultImageDiffDirectory;
+- (nullable NSString *)snapshotVerifyViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                             identifier:(nullable NSString *)identifier
+                                               suffixes:(NSOrderedSet *)suffixes
+                                      perPixelTolerance:(CGFloat)perPixelTolerance
+                                       overallTolerance:(CGFloat)overallTolerance
+                              defaultReferenceDirectory:(nullable NSString *)defaultReferenceDirectory
+                              defaultImageDiffDirectory:(nullable NSString *)defaultImageDiffDirectory;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.
@@ -278,6 +278,42 @@ NS_ASSUME_NONNULL_BEGIN
             perPixelTolerance:(CGFloat)perPixelTolerance
              overallTolerance:(CGFloat)overallTolerance
                         error:(NSError **)errorPtr;
+
+/**
+Performs the comparison or records a snapshot if recordMode is YES.
+@param image snapshot.
+@param referenceImagesDirectory The directory in which reference images are stored.
+@param imageDiffDirectory The directory in which failed image diffs are stored.
+@param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+@param overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
+@param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+@returns YES if the comparison (or saving of the reference image) succeeded.
+*/
+- (BOOL)compareSnapshotOfImage:(UIImage *)image
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+            imageDiffDirectory:(NSString *)imageDiffDirectory
+                    identifier:(nullable NSString *)identifier
+              overallTolerance:(CGFloat)overallTolerance
+                         error:(NSError **)errorPtr;
+
+/**
+Performs the comparison or records a snapshot if recordMode is YES.
+@param image snapshot.
+@param referenceImagesDirectory The directory in which reference images are stored.
+@param imageDiffDirectory The directory in which failed image diffs are stored.
+@param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+@param perPixelTolerance The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'. Each color shade difference represents a 0.390625% change.
+@param overallTolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care.
+@param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+@returns YES if the comparison (or saving of the reference image) succeeded.
+*/
+- (BOOL)compareSnapshotOfImage:(UIImage *)image
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+            imageDiffDirectory:(NSString *)imageDiffDirectory
+                    identifier:(nullable NSString *)identifier
+             perPixelTolerance:(CGFloat)perPixelTolerance
+              overallTolerance:(CGFloat)overallTolerance
+                         error:(NSError **)errorPtr;
 
 /**
  Checks if reference image with identifier based name exists in the reference images directory.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -73,31 +73,31 @@
 
 #pragma mark - Public API
 
-- (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
-                             identifier:(NSString *)identifier
-                               suffixes:(NSOrderedSet *)suffixes
-                       overallTolerance:(CGFloat)overallTolerance
-              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
-              defaultImageDiffDirectory:(NSString *)defaultImageDiffDirectory
+- (NSString *)snapshotVerifyViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                    identifier:(NSString *)identifier
+                                      suffixes:(NSOrderedSet *)suffixes
+                              overallTolerance:(CGFloat)overallTolerance
+                     defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
+                     defaultImageDiffDirectory:(NSString *)defaultImageDiffDirectory
 {
-    return [self snapshotVerifyViewOrLayer:viewOrLayer
-                                identifier:identifier
-                                  suffixes:suffixes
-                         perPixelTolerance:0
-                          overallTolerance:overallTolerance
-                 defaultReferenceDirectory:defaultReferenceDirectory
-                 defaultImageDiffDirectory:defaultImageDiffDirectory];
+    return [self snapshotVerifyViewOrLayerOrImage:viewOrLayerOrImage
+                                       identifier:identifier
+                                         suffixes:suffixes
+                                perPixelTolerance:0
+                                 overallTolerance:overallTolerance
+                        defaultReferenceDirectory:defaultReferenceDirectory
+                        defaultImageDiffDirectory:defaultImageDiffDirectory];
 }
 
-- (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
-                             identifier:(NSString *)identifier
-                               suffixes:(NSOrderedSet *)suffixes
-                      perPixelTolerance:(CGFloat)perPixelTolerance
-                       overallTolerance:(CGFloat)overallTolerance
-              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
-              defaultImageDiffDirectory:(NSString *)defaultImageDiffDirectory
+- (NSString *)snapshotVerifyViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                    identifier:(NSString *)identifier
+                                      suffixes:(NSOrderedSet *)suffixes
+                             perPixelTolerance:(CGFloat)perPixelTolerance
+                              overallTolerance:(CGFloat)overallTolerance
+                     defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
+                     defaultImageDiffDirectory:(NSString *)defaultImageDiffDirectory
 {
-    if (viewOrLayer == nil) {
+    if (viewOrLayerOrImage == nil) {
         return @"Object to be snapshotted must not be nil";
     }
 
@@ -120,7 +120,7 @@
 
     if (self.recordMode) {
         NSString *referenceImagesDirectory = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffixes.firstObject];
-        BOOL referenceImageSaved = [self _compareSnapshotOfViewOrLayer:viewOrLayer referenceImagesDirectory:referenceImagesDirectory imageDiffDirectory:imageDiffDirectory identifier:(identifier) perPixelTolerance:perPixelTolerance overallTolerance:overallTolerance error:&error];
+        BOOL referenceImageSaved = [self _compareSnapshotOfViewOrLayerOrImage:viewOrLayerOrImage referenceImagesDirectory:referenceImagesDirectory imageDiffDirectory:imageDiffDirectory identifier:(identifier) perPixelTolerance:perPixelTolerance overallTolerance:overallTolerance error:&error];
         if (!referenceImageSaved) {
             [errors addObject:error];
         }
@@ -133,7 +133,7 @@
             BOOL referenceImageAvailable = [self referenceImageRecordedInDirectory:referenceImagesDirectory identifier:(identifier) error:&error];
 
             if (referenceImageAvailable) {
-                BOOL comparisonSuccess = [self _compareSnapshotOfViewOrLayer:viewOrLayer referenceImagesDirectory:referenceImagesDirectory imageDiffDirectory:imageDiffDirectory identifier:identifier perPixelTolerance:perPixelTolerance overallTolerance:overallTolerance error:&error];
+                BOOL comparisonSuccess = [self _compareSnapshotOfViewOrLayerOrImage:viewOrLayerOrImage referenceImagesDirectory:referenceImagesDirectory imageDiffDirectory:imageDiffDirectory identifier:identifier perPixelTolerance:perPixelTolerance overallTolerance:overallTolerance error:&error];
                 [errors removeAllObjects];
                 if (comparisonSuccess) {
                     testSuccess = YES;
@@ -161,13 +161,13 @@
               overallTolerance:(CGFloat)overallTolerance
                          error:(NSError **)errorPtr
 {
-    return [self _compareSnapshotOfViewOrLayer:layer
-                      referenceImagesDirectory:referenceImagesDirectory
-                            imageDiffDirectory:imageDiffDirectory
-                                    identifier:identifier
-                             perPixelTolerance:0
-                              overallTolerance:overallTolerance
-                                         error:errorPtr];
+    return [self _compareSnapshotOfViewOrLayerOrImage:layer
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:0
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
 }
 
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer
@@ -178,13 +178,13 @@
               overallTolerance:(CGFloat)overallTolerance
                          error:(NSError **)errorPtr
 {
-    return [self _compareSnapshotOfViewOrLayer:layer
-                      referenceImagesDirectory:referenceImagesDirectory
-                            imageDiffDirectory:(NSString *)imageDiffDirectory
-                                    identifier:identifier
-                             perPixelTolerance:perPixelTolerance
-                              overallTolerance:overallTolerance
-                                         error:errorPtr];
+    return [self _compareSnapshotOfViewOrLayerOrImage:layer
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:(NSString *)imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:perPixelTolerance
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
 }
 
 - (BOOL)compareSnapshotOfView:(UIView *)view
@@ -194,13 +194,13 @@
              overallTolerance:(CGFloat)overallTolerance
                         error:(NSError **)errorPtr
 {
-    return [self _compareSnapshotOfViewOrLayer:view
-                      referenceImagesDirectory:referenceImagesDirectory
-                            imageDiffDirectory:imageDiffDirectory
-                                    identifier:identifier
-                             perPixelTolerance:0
-                              overallTolerance:overallTolerance
-                                         error:errorPtr];
+    return [self _compareSnapshotOfViewOrLayerOrImage:view
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:0
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
 }
 
 - (BOOL)compareSnapshotOfView:(UIView *)view
@@ -211,13 +211,46 @@
              overallTolerance:(CGFloat)overallTolerance
                         error:(NSError **)errorPtr
 {
-    return [self _compareSnapshotOfViewOrLayer:view
-                      referenceImagesDirectory:referenceImagesDirectory
-                            imageDiffDirectory:(NSString *)imageDiffDirectory
-                                    identifier:identifier
-                             perPixelTolerance:perPixelTolerance
-                              overallTolerance:overallTolerance
-                                         error:errorPtr];
+    return [self _compareSnapshotOfViewOrLayerOrImage:view
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:(NSString *)imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:perPixelTolerance
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
+}
+
+- (BOOL)compareSnapshotOfImage:(UIImage *)image
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+            imageDiffDirectory:(NSString *)imageDiffDirectory
+                    identifier:(NSString *)identifier
+              overallTolerance:(CGFloat)overallTolerance
+                         error:(NSError **)errorPtr
+{
+    return [self _compareSnapshotOfViewOrLayerOrImage:image
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:0
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
+}
+
+- (BOOL)compareSnapshotOfImage:(UIImage *)image
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+            imageDiffDirectory:(NSString *)imageDiffDirectory
+                    identifier:(NSString *)identifier
+             perPixelTolerance:(CGFloat)perPixelTolerance
+              overallTolerance:(CGFloat)overallTolerance
+                         error:(NSError **)errorPtr
+{
+    return [self _compareSnapshotOfViewOrLayerOrImage:image
+                             referenceImagesDirectory:referenceImagesDirectory
+                                   imageDiffDirectory:(NSString *)imageDiffDirectory
+                                           identifier:identifier
+                                    perPixelTolerance:perPixelTolerance
+                                     overallTolerance:overallTolerance
+                                                error:errorPtr];
 }
 
 - (BOOL)referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
@@ -259,22 +292,22 @@
 
 #pragma mark - Private API
 
-- (BOOL)_compareSnapshotOfViewOrLayer:(id)viewOrLayer
-             referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                   imageDiffDirectory:(NSString *)imageDiffDirectory
-                           identifier:(NSString *)identifier
-                    perPixelTolerance:(CGFloat)perPixelTolerance
-                     overallTolerance:(CGFloat)overallTolerance
-                                error:(NSError **)errorPtr
+- (BOOL)_compareSnapshotOfViewOrLayerOrImage:(id)viewOrLayerOrImage
+                    referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                          imageDiffDirectory:(NSString *)imageDiffDirectory
+                                  identifier:(NSString *)identifier
+                           perPixelTolerance:(CGFloat)perPixelTolerance
+                            overallTolerance:(CGFloat)overallTolerance
+                                       error:(NSError **)errorPtr
 {
     _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
     _snapshotController.imageDiffDirectory = imageDiffDirectory;
-    return [_snapshotController compareSnapshotOfViewOrLayer:viewOrLayer
-                                                    selector:self.invocation.selector
-                                                  identifier:identifier
-                                           perPixelTolerance:perPixelTolerance
-                                            overallTolerance:overallTolerance
-                                                       error:errorPtr];
+    return [_snapshotController compareSnapshotOfViewOrLayerOrImage:viewOrLayerOrImage
+                                                           selector:self.invocation.selector
+                                                         identifier:identifier
+                                                  perPixelTolerance:perPixelTolerance
+                                                   overallTolerance:overallTolerance
+                                                              error:errorPtr];
 }
 
 @end

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -126,22 +126,22 @@ extern NSString *const FBDiffedImageKey;
 
 /**
  Performs the comparison of a view or layer.
- @param viewOrLayer The view or layer to snapshot.
+ @param viewOrLayerOrImage The view or layer to snapshot.
  @param selector The test method being run.
  @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
  @param overallTolerance The percentage of pixels that can differ and still be considered 'identical'.
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
-- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
-                            selector:(SEL)selector
-                          identifier:(nullable NSString *)identifier
-                    overallTolerance:(CGFloat)overallTolerance
-                               error:(NSError **)errorPtr;
+- (BOOL)compareSnapshotOfViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                   selector:(SEL)selector
+                                 identifier:(nullable NSString *)identifier
+                           overallTolerance:(CGFloat)overallTolerance
+                                      error:(NSError **)errorPtr;
 
 /**
  Performs the comparison of a view or layer.
- @param viewOrLayer The view or layer to snapshot.
+ @param viewOrLayerOrImage The view or layer to snapshot.
  @param selector The test method being run.
  @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
  @param perPixelTolerance The percentage a given pixel's R,G,B and A components can differ and still be considered 'identical'.
@@ -149,12 +149,12 @@ extern NSString *const FBDiffedImageKey;
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
-- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
-                            selector:(SEL)selector
-                          identifier:(nullable NSString *)identifier
-                   perPixelTolerance:(CGFloat)perPixelTolerance
-                    overallTolerance:(CGFloat)overallTolerance
-                               error:(NSError **)errorPtr;
+- (BOOL)compareSnapshotOfViewOrLayerOrImage:(id)viewOrLayerOrImage
+                                   selector:(SEL)selector
+                                 identifier:(nullable NSString *)identifier
+                          perPixelTolerance:(CGFloat)perPixelTolerance
+                           overallTolerance:(CGFloat)overallTolerance
+                                      error:(NSError **)errorPtr;
 
 /**
  Loads a reference image.

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -9,7 +9,7 @@
 
 public extension FBSnapshotTestCase {
     func FBSnapshotVerifyView(_ view: UIView, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
+    FBSnapshotVerifyViewOrLayerOrImage(view, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
   
     func FBSnapshotVerifyViewController(_ viewController: UIViewController, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
@@ -21,10 +21,14 @@ public extension FBSnapshotTestCase {
   }
 
     func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
+    FBSnapshotVerifyViewOrLayerOrImage(layer, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
   }
 
-  private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+    func FBSnapshotVerifyImage(_ image: UIImage, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
+    FBSnapshotVerifyViewOrLayerOrImage(image, identifier: identifier, suffixes: suffixes, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance, file: file, line: line)
+  }
+
+  private func FBSnapshotVerifyViewOrLayerOrImage(_ viewOrLayerOrImage: AnyObject, identifier: String? = nil, suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), perPixelTolerance: CGFloat = 0, overallTolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: nil)
     let envImageDiffDirectory = self.getImageDiffDirectory(withDefault: nil)
     var error: NSError?
@@ -33,24 +37,32 @@ public extension FBSnapshotTestCase {
     for suffix in suffixes {
       let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
       let imageDiffDirectory = envImageDiffDirectory
-      if viewOrLayer.isKind(of: UIView.self) {
+      if viewOrLayerOrImage.isKind(of: UIView.self) {
         do {
-          try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
+          try compareSnapshot(of: viewOrLayerOrImage as! UIView, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
           comparisonSuccess = true
         } catch let error1 as NSError {
           error = error1
           comparisonSuccess = false
         }
-      } else if viewOrLayer.isKind(of: CALayer.self) {
+      } else if viewOrLayerOrImage.isKind(of: CALayer.self) {
         do {
-          try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
+          try compareSnapshot(of: viewOrLayerOrImage as! CALayer, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
+          comparisonSuccess = true
+        } catch let error1 as NSError {
+          error = error1
+          comparisonSuccess = false
+        }
+      } else if viewOrLayerOrImage.isKind(of: UIImage.self) {
+        do {
+          try compareSnapshot(of: viewOrLayerOrImage as! UIImage, referenceImagesDirectory: referenceImagesDirectory, imageDiffDirectory: imageDiffDirectory, identifier: identifier, perPixelTolerance: perPixelTolerance, overallTolerance: overallTolerance)
           comparisonSuccess = true
         } catch let error1 as NSError {
           error = error1
           comparisonSuccess = false
         }
       } else {
-        assertionFailure("Only UIView and CALayer classes can be snapshotted")
+        assertionFailure("Only UIView, CALayer and UIImage classes can be snapshotted")
       }
 
       assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)


### PR DESCRIPTION
Add UIImage parameter to FBSnapshotVerify function.

Use the UIImage parameter to perform a snapshot test.

There are two reasons.

1. I want to reduce the resolution of the snapshot to save the file size.
1. The landscape iPad snapshot rotates 90 °.

Thank you for your review.