### PR TITLE
Add removesErrorSuffix to make it easier to use with a test that `throws`

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -168,6 +168,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
+/// Whether to remove the "AndReturnError" suffix used when a test `throws` in Swift.
+/// This allows to change a test between throwing and not throwing without recording snapshots again.
+/// The default is YES.
+@property (readwrite, nonatomic, assign) BOOL removesErrorSuffix;
+
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
 

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseSwiftTests.swift
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseSwiftTests.swift
@@ -15,7 +15,7 @@ class FBSnapshotTestCaseSwiftTest: FBSnapshotTestCase {
     recordMode = false
   }
 
-  func testExample() {
+  func testExample() throws {
     let view = UIView(frame: CGRect(x: 0, y: 0, width: 64, height: 64))
     view.backgroundColor = UIColor.blue
     FBSnapshotVerifyView(view)


### PR DESCRIPTION
This changes the default behavior, so it's technically a breaking change. However, I think this default behavior makes more sense - and hopefully it won't break things to many people since adding `throws` to a unit test is relatively new (~1 year)