### PR TITLE
Fix path to SwiftSupport.swift in BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,7 +20,7 @@ objc_library(
 swift_library(
     name = "iOSSnapshotTestCase",
     module_name = "iOSSnapshotTestCase",
-    srcs = ["src/iOSSnapshotTestCaseCore/SwiftSupport.swift"],
+    srcs = ["src/iOSSnapshotTestCase/SwiftSupport.swift"],
     deps = [
         ":iOSSnapshotTestCaseCore"
     ],


### PR DESCRIPTION
A CI check would be pretty easy to make and cheap to run if BUILD.bazel is something *iOS-snapshot-test-case* wants to support (which I think is great!)

I could chip in a PR for that as well, though it might be a little slow for a non-maintainer to test it.