### PR TITLE
Add removesErrorSuffix to make it easier to use with a test that throws

### DIFF
--- a/demos/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseSwiftTests.swift
+++ b/demos/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseSwiftTests.swift
@@ -15,7 +15,7 @@ class FBSnapshotTestCaseSwiftTest: FBSnapshotTestCase {
     recordMode = false
   }
 
-  func testExample() {
+  func testExample() throws {
     let view = UIView(frame: CGRect(x: 0, y: 0, width: 64, height: 64))
     view.backgroundColor = UIColor.blue
     FBSnapshotVerifyView(view)

--- a/demos/iOSSnapshotTestCaseCarthageDemo/iOSSnapshotTestCaseCarthageDemoSwiftTests/iOSSnapshotTestCaseCarthageDemoSwiftTests.swift
+++ b/demos/iOSSnapshotTestCaseCarthageDemo/iOSSnapshotTestCaseCarthageDemoSwiftTests/iOSSnapshotTestCaseCarthageDemoSwiftTests.swift
@@ -16,7 +16,7 @@ class iOSSnapshotTestCaseCarthageDemoSwiftTests: FBSnapshotTestCase {
         recordMode = false
     }
 
-    func testExample() {
+    func testExample() throws {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 64, height: 64))
         view.backgroundColor = UIColor.blue
         FBSnapshotVerifyView(view)

--- a/demos/iOSSnapshotTestCaseSwiftPMDemo/Tests iOS/iOSSnapshotTestCaseSwiftPMDemoSwiftTests.swift
+++ b/demos/iOSSnapshotTestCaseSwiftPMDemo/Tests iOS/iOSSnapshotTestCaseSwiftPMDemoSwiftTests.swift
@@ -16,7 +16,7 @@ class iOSSnapshotTestCaseSwiftPMDemoSwiftTests: FBSnapshotTestCase {
         recordMode = false
     }
 
-    func testExample() {
+    func testExample() throws {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 64, height: 64))
         view.backgroundColor = UIColor.blue
         FBSnapshotVerifyView(view)

--- a/src/iOSSnapshotTestCaseCore/FBSnapshotTestCase.m
+++ b/src/iOSSnapshotTestCaseCore/FBSnapshotTestCase.m
@@ -20,6 +20,7 @@
 {
     [super setUp];
     _snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[self class]];
+    _removesErrorSuffix = YES;
 }
 
 - (void)tearDown
@@ -236,7 +237,7 @@
 {
     NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
     _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
-    UIImage *referenceImage = [_snapshotController referenceImageForSelector:self.invocation.selector
+    UIImage *referenceImage = [_snapshotController referenceImageForSelector:[self adjustedCurrentTestSelector]
                                                                   identifier:identifier
                                                                        error:errorPtr];
 
@@ -286,11 +287,25 @@
     _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
     _snapshotController.imageDiffDirectory = imageDiffDirectory;
     return [_snapshotController compareSnapshotOfViewOrLayer:viewOrLayer
-                                                    selector:self.invocation.selector
+                                                    selector:[self adjustedCurrentTestSelector]
                                                   identifier:identifier
                                            perPixelTolerance:perPixelTolerance
                                             overallTolerance:overallTolerance
                                                        error:errorPtr];
 }
+
+- (SEL)adjustedCurrentTestSelector {
+     SEL selector = self.invocation.selector;
+     if (!self.removesErrorSuffix || self.invocation.methodSignature.numberOfArguments != 3) {
+         return selector;
+     }
+
+      NSString *name = NSStringFromSelector(selector);
+     if ([name hasSuffix:@"AndReturnError:"]) {
+         return NSSelectorFromString([name stringByReplacingOccurrencesOfString:@"AndReturnError:" withString:@""]);
+     }
+
+      return selector;
+ }
 
 @end

--- a/src/iOSSnapshotTestCaseCore/Public/FBSnapshotTestCase.h
+++ b/src/iOSSnapshotTestCaseCore/Public/FBSnapshotTestCase.h
@@ -174,6 +174,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
+/// Whether to remove the "AndReturnError" suffix used when a test `throws` in Swift.
+/// This allows to change a test between throwing and not throwing without recording snapshots again.
+/// The default is YES.
+@property (readwrite, nonatomic, assign) BOOL removesErrorSuffix;
+
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
 


### PR DESCRIPTION
This changes the default behavior, so it's technically a breaking change. However, I think this default behavior makes more sense - and hopefully it won't break things to many people since adding throws to a unit test is relatively new (~1 year)

Updated version of #145