### PR TITLE
Adds link to XCTest in objc_library rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ objc_library(
     copts = [
         "-Wno-deprecated-declarations"
     ],
+    sdk_frameworks = ["XCTest"],
     visibility = ["//visibility:public"]
 )
 


### PR DESCRIPTION
This allows the bazel configuration to compile
under certain scenarios